### PR TITLE
Enable deployment to multi env and automation support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,6 +361,7 @@ infrastructure.env
 infrastructure.debug.env
 infra_output.json
 random.txt
+.state
 
 # Azure Developer CLI outputs
 .azure

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -13,6 +13,7 @@ param randomString string
 @description('Primary location for all resources')
 param location string
 
+param buildNumber string = 'local'
 param useExistingAOAIService bool
 param azureOpenAIServiceName string
 param azureOpenAIServiceKey string
@@ -39,7 +40,7 @@ param chatGptModelName string = 'gpt-35-turbo'
 param principalId string = ''
 
 var abbrs = loadJsonContent('abbreviations.json')
-var tags = { ProjectName: 'Information Assistant' }
+var tags = { ProjectName: 'Information Assistant', BuildNumber: buildNumber }
 var prefix = 'infoasst'
 
 // Organize resources in a resource group

--- a/infra/main.parameters.json.template
+++ b/infra/main.parameters.json.template
@@ -34,6 +34,9 @@
     },
     "searchServicesSkuName": {
       "value": "standard"
+    },
+    "buildNumber": {
+      "value": "${BUILD_NUMBER}"
     }
   }
 }

--- a/scripts/load-env.sh
+++ b/scripts/load-env.sh
@@ -17,6 +17,14 @@ fi
 
 echo "Environment set: $ENVIRONMENT_NAME."
 
+if [[ -n $IN_AUTOMATION ]]; then
+    if [[ -z $BUILD_BUILDID ]]; then
+        echo "Require BUILD_BUILDID to be set for CI builds"
+        exit 1        
+    fi
+    export BUILD_NUMBER=$BUILD_BUILDNUMBER
+fi
+
 # Pull in variables dependent on the envionment we are deploying to.
 if [ -f "$ENV_DIR/environments/$ENVIRONMENT_NAME.env" ]; then
     echo "Loading environment variables for $ENVIRONMENT_NAME."


### PR DESCRIPTION
In this update the "random.txt" file used by the BICEP deployment has been moved from the root of `/infrastructure` to now be in a folder name `/infrastructure/.state`. Within this folder new folders will get created that match the value provided in the **WORKSPACE** value in `local.env`. This will allow each target environment (based on workspace name) to keep separate random token values. 

In addition, it extends the `inf-create.sh` file to support the **IN_AUTOMATION** flag used by CI/CD pipelines to allow the `random.txt` files to be uploaded to blob storage for durable CI/CD deployments. It also now adds the **BUILD_BUILDNUMBER** to the tags of the resource group created to match the AzDO pipeline build number. 