### PR TITLE
Set maxFailedItems to -1 to allow partial sucess

### DIFF
--- a/azure_search/create_all_indexer.json
+++ b/azure_search/create_all_indexer.json
@@ -10,7 +10,7 @@
   },
   "parameters": {
     "batchSize": null,
-    "maxFailedItems": 0,
+    "maxFailedItems": -1,
     "maxFailedItemsPerBatch": 0,
     "base64EncodeKeys": null,
     "configuration": {


### PR DESCRIPTION
Previously the Azure Cognitive Search indexer would simply fail and stop processing any new document when it encountered a single error in a file. By changing the `maxFailedItems` to "-1" the indexer will continue to process new files and simply report the run as "Partial Success". 