### PR TITLE
Use AzureKeyCredentials instead of DefaultAzureCredentials

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -5,6 +5,7 @@ import logging
 import openai
 from flask import Flask, request, jsonify
 from azure.identity import DefaultAzureCredential
+from azure.core.credentials import AzureKeyCredential
 from azure.search.documents import SearchClient
 from approaches.retrievethenread import RetrieveThenReadApproach
 from approaches.readretrieveread import ReadRetrieveReadApproach
@@ -14,8 +15,10 @@ from azure.storage.blob import BlobServiceClient
 
 # Replace these with your own values, either in environment variables or directly here
 AZURE_BLOB_STORAGE_ACCOUNT = os.environ.get("AZURE_BLOB_STORAGE_ACCOUNT") or "mystorageaccount"
+AZURE_BLOB_STORAGE_KEY = os.environ.get("AZURE_BLOB_STORAGE_KEY")
 AZURE_BLOB_STORAGE_CONTAINER = os.environ.get("AZURE_BLOB_STORAGE_CONTAINER") or "content"
 AZURE_SEARCH_SERVICE = os.environ.get("AZURE_SEARCH_SERVICE") or "gptkb"
+AZURE_SEARCH_SERVICE_KEY = os.environ.get("AZURE_SEARCH_SERVICE_KEY")
 AZURE_SEARCH_INDEX = os.environ.get("AZURE_SEARCH_INDEX") or "gptkbindex"
 AZURE_OPENAI_SERVICE = os.environ.get("AZURE_OPENAI_SERVICE") or "myopenai"
 AZURE_OPENAI_GPT_DEPLOYMENT = os.environ.get("AZURE_OPENAI_GPT_DEPLOYMENT") or "davinci"
@@ -31,6 +34,7 @@ KB_FIELDS_SOURCEPAGE = os.environ.get("KB_FIELDS_SOURCEPAGE") or "file_storage_p
 # keys for each service
 # If you encounter a blocking error during a DefaultAzureCredntial resolution, you can exclude the problematic credential by using a parameter (ex. exclude_shared_token_cache_credential=True)
 azure_credential = DefaultAzureCredential()
+azure_search_key_credential = AzureKeyCredential(AZURE_SEARCH_SERVICE_KEY)
 
 # Used by the OpenAI SDK
 openai.api_type = "azure"
@@ -46,10 +50,10 @@ openai.api_key = AZURE_OPENAI_SERVICE_KEY
 search_client = SearchClient(
     endpoint=f"https://{AZURE_SEARCH_SERVICE}.search.windows.net",
     index_name=AZURE_SEARCH_INDEX,
-    credential=azure_credential)
+    credential=azure_search_key_credential)
 blob_client = BlobServiceClient(
     account_url=f"https://{AZURE_BLOB_STORAGE_ACCOUNT}.blob.core.windows.net", 
-    credential=azure_credential)
+    credential=AZURE_BLOB_STORAGE_KEY)
 blob_container = blob_client.get_container_client(AZURE_BLOB_STORAGE_CONTAINER)
 
 # Various approaches to integrate GPT and external knowledge, most applications will use a single one of these patterns

--- a/infra/core/search/search-services.bicep
+++ b/infra/core/search/search-services.bicep
@@ -56,5 +56,7 @@ resource cogService 'Microsoft.CognitiveServices/accounts@2022-10-01' = {
 output id string = search.id
 output endpoint string = 'https://${name}.search.windows.net/'
 output name string = search.name
+#disable-next-line outputs-should-not-contain-secrets
+output searchServiceKey string = search.listAdminKeys().primaryKey
 #disable-next-line outputs-should-not-contain-secrets 
 output cogServiceKey string = cogService.listKeys().key1

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -101,6 +101,7 @@ module backend 'core/host/appservice.bicep' = {
       AZURE_OPENAI_SERVICE: azureOpenAIServiceName//cognitiveServices.outputs.name
       AZURE_SEARCH_INDEX: searchIndexName
       AZURE_SEARCH_SERVICE: searchServices.outputs.name
+      AZURE_SEARCH_SERVICE_KEY: searchServices.outputs.searchServiceKey
       AZURE_OPENAI_GPT_DEPLOYMENT: gptDeploymentName
       AZURE_OPENAI_CHATGPT_DEPLOYMENT: chatGptDeploymentName
       AZURE_OPENAI_SERVICE_KEY: azureOpenAIServiceKey
@@ -284,6 +285,7 @@ output AZURE_LOCATION string = location
 output AZURE_OPENAI_SERVICE string = azureOpenAIServiceName//cognitiveServices.outputs.name
 output AZURE_SEARCH_INDEX string = searchIndexName
 output AZURE_SEARCH_SERVICE string = searchServices.outputs.name
+output AZURE_SEARCH_KEY string = searchServices.outputs.searchServiceKey
 output AZURE_STORAGE_ACCOUNT string = storage.outputs.name
 output AZURE_STORAGE_CONTAINER string = containerName
 output AZURE_STORAGE_KEY string = storage.outputs.key

--- a/scripts/json-to-env.debug.sh
+++ b/scripts/json-to-env.debug.sh
@@ -55,6 +55,14 @@ jq -r  '
         {
             "path": "azurE_OPENAI_SERVICE_KEY",
             "env_var": "AZURE_OPENAI_SERVICE_KEY"
+        },
+        {
+            "path": "azurE_STORAGE_KEY",
+            "env_var": "AZURE_BLOB_STORAGE_KEY"
+        },
+        {
+            "path": "azurE_SEARCH_KEY",
+            "env_var": "AZURE_SEARCH_SERVICE_KEY"
         }
     ]
         as $env_vars_to_extract

--- a/scripts/json-to-env.sh
+++ b/scripts/json-to-env.sh
@@ -61,6 +61,10 @@ jq -r  '
         {
             "path": "azurE_STORAGE_KEY",
             "env_var": "AZURE_BLOB_STORAGE_KEY"
+        },
+        {
+            "path": "azurE_SEARCH_KEY",
+            "env_var": "AZURE_SEARCH_SERVICE_KEY"
         }
     ]
         as $env_vars_to_extract


### PR DESCRIPTION
In the webapp backend, the code was using `DefaultAzureCredential` to authenticate to Azure Cognitive Search and Azure Blob Storage. This required the System Assigned Identity to have sufficient roles when deployed in Azure, and required the developer to be logged into an account with sufficient roles when debugging. To reduce the role management, simply updated the connections to use the following:

Azure Cognitive Search now uses:
``` python
azure_search_key_credential = AzureKeyCredential(AZURE_SEARCH_SERVICE_KEY)
SearchClient(
    endpoint=f"https://{AZURE_SEARCH_SERVICE}.search.windows.net",
    index_name=AZURE_SEARCH_INDEX,
    credential=azure_search_key_credential)
```

Azure Blob Storage now uses:
``` python
BlobServiceClient(
    account_url=f"https://{AZURE_BLOB_STORAGE_ACCOUNT}.blob.core.windows.net", 
    credential=AZURE_BLOB_STORAGE_KEY)
```
The BlobService client does not support `AzureKeyCredential` rather just wants the Admin Key text for the credential object per https://learn.microsoft.com/en-us/python/api/overview/azure/storage-blob-readme?view=azure-python#types-of-credentials