### PR TITLE
Update webapp deploy to async and increase timeout

### DIFF
--- a/scripts/deploy-webapp.sh
+++ b/scripts/deploy-webapp.sh
@@ -14,4 +14,4 @@ end=`date -u -d "3 years" '+%Y-%m-%dT%H:%MZ'`
 cd $BINARIES_OUTPUT_PATH
 file=$(az storage blob upload --account-name $AZURE_BLOB_STORAGE_ACCOUNT --account-key $AZURE_BLOB_STORAGE_KEY --container-name website --name webapp.zip --file webapp.zip --overwrite)
 sas=$(az storage blob generate-sas --account-name $AZURE_BLOB_STORAGE_ACCOUNT --account-key $AZURE_BLOB_STORAGE_KEY --container-name website --name webapp.zip --permissions r --expiry $end --output tsv)
-az webapp deploy --name $AZURE_WEBAPP_NAME --resource-group $RESOURCE_GROUP_NAME --type zip --src-url "https://$AZURE_BLOB_STORAGE_ACCOUNT.blob.core.windows.net/website/webapp.zip?$sas" --timeout 300000
+az webapp deploy --name $AZURE_WEBAPP_NAME --resource-group $RESOURCE_GROUP_NAME --type zip --src-url "https://$AZURE_BLOB_STORAGE_ACCOUNT.blob.core.windows.net/website/webapp.zip?$sas" --async true --timeout 600000


### PR DESCRIPTION
Update the Azure CLI commands for webapp deployment to use the `--async` parameter and increase the timeout from 300000 to 600000 ms. 