### PR TITLE
Add urlparse to handle special characters in file names

### DIFF
--- a/app/backend/approaches/chatreadretrieveread.py
+++ b/app/backend/approaches/chatreadretrieveread.py
@@ -3,6 +3,7 @@ from azure.search.documents import SearchClient
 from azure.search.documents.models import QueryType
 from approaches.approach import Approach
 from text import nonewlines
+import urllib.parse
 
 # Simple retrieve-then-read implementation, using the Cognitive Search and OpenAI APIs directly. It first retrieves
 # top documents from search, then constructs a prompt with them, and then uses OpenAI to generate an completion 
@@ -91,9 +92,9 @@ Search query:
                 # if not using semantic captions, use the content instead of the captions
                 # include the "FileX" monikor in the prompt, and the actual file name in the response
                 results.append(f"File{idx} " + "| " + nonewlines(doc[self.content_field]))
-                data_points.append("/".join(doc[self.sourcepage_field].split("/")[4:]) + "| " + nonewlines(doc[self.content_field]))
+                data_points.append("/".join(urllib.parse.unquote(doc[self.sourcepage_field]).split("/")[4:]) + "| " + nonewlines(doc[self.content_field]))
             # add the "FileX" monikor and full file name to the citation lookup
-            citation_lookup[f"File{idx}"] = doc[self.sourcepage_field]
+            citation_lookup[f"File{idx}"] = urllib.parse.unquote(doc[self.sourcepage_field])
         # create a single string of all the results to be used in the prompt
         content = "\n ".join(results)
 


### PR DESCRIPTION
In some cases the file names had special characters that Azure Semantic Search were returning with the file name fully URL encoded. This was causing issues when trying to retrieve the document blob storage URL for citations. 

To fix this we included the urllib.parse library and use `urllib.parse.unquote()` around the file name fields being returned from the Cognitive Search query results. 