### PR TITLE
Geearl/5677 docx

### DIFF
--- a/functions/requirements.txt
+++ b/functions/requirements.txt
@@ -10,3 +10,4 @@ nltk == 3.8.1
 azure-core == 1.26.4
 beautifulsoup4 == 4.12.2
 lxml == 4.9.2
+mammoth == 1.5.1


### PR DESCRIPTION
This change builds on the html preprocessor. The PR now accepts docx files and uses the mammoth library to convert them to html and then use the existing processes to cerate an html document map and then chunks.. A known issue is that tables don't make it to chunks correctly. this seems to be across all html files - there is a defect on the board for this