### PR TITLE
Encode URLs when loading citations to avoid special character issues

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -3,6 +3,7 @@ import mimetypes
 import time
 import logging
 import openai
+import urllib.parse
 from datetime import datetime, timedelta
 from flask import Flask, request, jsonify
 from azure.identity import DefaultAzureCredential
@@ -87,7 +88,7 @@ def content_file(path):
     if mime_type == "text/plain" and file_extension[0] in ["htm","html"]:
         mime_type = "text/html"
     print("Using mime type: " + mime_type + "for file with extension: " + file_extension[0])
-    return blob.readall(), 200, {"Content-Type": mime_type, "Content-Disposition": f"inline; filename={path}"}
+    return blob.readall(), 200, {"Content-Type": mime_type, "Content-Disposition": f"inline; filename={urllib.parse.quote(path, safe='')}"}
 
     
 @app.route("/ask", methods=["POST"])

--- a/app/frontend/src/api/api.ts
+++ b/app/frontend/src/api/api.ts
@@ -70,14 +70,7 @@ export async function chatApi(options: ChatRequest): Promise<AskResponse> {
 }
 
 export function getCitationFilePath(citation: string): string {
-    //const xhr = new XMLHttpRequest();
-    //const url = '/contenturl';
-    //xhr.open('GET', url, true);
-    //xhr.setRequestHeader('Content-Type', 'application/json');
-    //const body = JSON.stringify({"path": citation});
-    //xhr.send(body);
-    //return xhr.response;
-    return `/content/${citation}`;
+    return `/content/${encodeURIComponent(citation)}`;
 }
 
 export async function getBlobClientUrl(): Promise<string> {


### PR DESCRIPTION
When some files have special characters in their names the resulting HTML/JS that was created was invalid and not loading. So on the api call to get the file from blob storage we made changes to URL encode the file name on the way in and out of the API call.