### PR TITLE
Update index key mapper to fixed length to avoid long keys

### DIFF
--- a/azure_search/create_all_indexer.json
+++ b/azure_search/create_all_indexer.json
@@ -27,7 +27,7 @@
       "sourceFieldName": "metadata_storage_path",
       "targetFieldName": "metadata_storage_path",
       "mappingFunction": {
-        "name": "base64Encode",
+        "name": "fixedLengthEncode",
         "parameters": null
       }
     },


### PR DESCRIPTION
Previously we were using `base64encode` as the "mappingFunction" for the search index key value. But since we create folders in Azure Blob storage using the file name that then include the chunk files, the full URL for the blob in Azure Storage can generate a more than 1024 length base64 string. This caused an error when indexing the files in Azure Cognitive Search. 

To solve this issue we switched to the `fixedLengthEncode` mapping Function per documentation at https://learn.microsoft.com/en-us/azure/search/search-indexer-field-mappings?tabs=rest#example---map-document-keys-that-are-too-long 