### PR TITLE
missing entry

### DIFF
--- a/infra/core/function/function.bicep
+++ b/infra/core/function/function.bicep
@@ -108,6 +108,10 @@ resource functionApp 'Microsoft.Web/sites@2022-09-01' = {
       ]
       appSettings: [
         {
+          name: 'AzureWebJobsStorage'
+          value: 'DefaultEndpointsProtocol=https;AccountName=${blobStorageAccountName};EndpointSuffix=${environment().suffixes.storage};AccountKey=${blobStorageAccountKey}'
+        }
+        {
           name: 'WEBSITE_CONTENTAZUREFILECONNECTIONSTRING'
           value: 'DefaultEndpointsProtocol=https;AccountName=${blobStorageAccountName};EndpointSuffix=${environment().suffixes.storage};AccountKey=${blobStorageAccountKey}'
         }


### PR DESCRIPTION
when doing the function refactoring, I cleaned up some appsettings, one of which was  was AzureWebJobsStorage.  This appears to be a system required setting for the function to store content as it processes in the background