### PR TITLE
Geearl/5797 parser error 2

### DIFF
--- a/functions/parse_docs/__init__.py
+++ b/functions/parse_docs/__init__.py
@@ -48,8 +48,7 @@ def main(myblob: func.InputStream):
 
     
     """ Function to read PDF files and extract text using Azure Form Recognizer"""
-    statusLog.state = State.STARTED
-    statusLog.upsert_document(myblob.name, 'File Uploaded', StatusClassification.INFO, True)
+    statusLog.upsert_document(myblob.name, 'File Uploaded', StatusClassification.INFO, State.STARTED, True)    
     
     logging.info(f"Python blob trigger function processed blob \n"
                  f"Name: {myblob.name}\n"


### PR DESCRIPTION
error calling then refactored logging code from the old parser. it was failing because the old code was mixing up the function parameters it was sending over