### PR TITLE
add "allowSkillsetToReadFileData" property to search indexer

### DIFF
--- a/azure_search/create_all_indexer.json
+++ b/azure_search/create_all_indexer.json
@@ -19,7 +19,8 @@
       "imageAction": "generateNormalizedImages",
       "parsingMode": "default",
       "failOnUnprocessableDocument": false,
-      "failOnUnsupportedContentType": false
+      "failOnUnsupportedContentType": false,
+      "allowSkillsetToReadFileData": true
     }
   },
   "fieldMappings": [


### PR DESCRIPTION
We discovered that warnings were being generated in the search indexer when trying to extract document content using the "document/file_data" attributes. Turns out we needed to enable `allowSkillsetToReadFileData` on the indexer. 

![image](https://github.com/microsoft/PubSec-Info-Assistant/assets/48474707/7ddd3746-b1aa-4723-9faf-ca3211ca1f8f)
