### PR TITLE
Geearl/5857 code error

### DIFF
--- a/functions/FileFormRecPollingPDF/__init__.py
+++ b/functions/FileFormRecPollingPDF/__init__.py
@@ -112,13 +112,13 @@ def main(msg: func.QueueMessage) -> None:
                     statusLog.upsert_document(blob_name, f'{function_name} - maximum submissions to FR reached', StatusClassification.ERROR, State.ERROR)     
             else:
                 # unexpected status returned by FR
-                statusLog.upsert_document(blob_name, f'{function_name} - unhandled response from form Recognizer - {response.text}', StatusClassification.ERROR, State.ERROR)  
+                statusLog.upsert_document(blob_name, f'{function_name} - unhandled response from form Recognizer- code: {response.status_code} status: {response_status} - text: {response.text}', StatusClassification.ERROR, State.ERROR)  
         else:
             statusLog.upsert_document(blob_name, f'{function_name} - Error raised by FR polling', StatusClassification.ERROR, State.ERROR)    
                             
     except Exception as e:
         # a general error 
-        statusLog.upsert_document(blob_name, f"{function_name} - An error occurred - {str(e)}", StatusClassification.ERROR, State.ERROR)
+        statusLog.upsert_document(blob_name, f"{function_name} - An error occurred - code: {response.status_code} - {str(e)}", StatusClassification.ERROR, State.ERROR)
 
 
 @retry(stop=stop_after_attempt(MAX_READ_ATTEMPTS), wait=wait_fixed(5))

--- a/functions/FileFormRecSubmissionPDF/__init__.py
+++ b/functions/FileFormRecSubmissionPDF/__init__.py
@@ -100,7 +100,7 @@ def main(msg: func.QueueMessage) -> None:
 
         else:
             # general error occurred
-            statusLog.upsert_document(blob_path, f'{function_name} - Error on PDF submission to FR - {response.code} {response.message}', StatusClassification.ERROR, State.ERROR) 
+            statusLog.upsert_document(blob_path, f'{function_name} - Error on PDF submission to FR - {response.status_code} - {response.message}', StatusClassification.ERROR, State.ERROR) 
             
     except Exception as e:
         statusLog.upsert_document(blob_path, f"{function_name} - An error occurred - {str(e)}", StatusClassification.ERROR, State.ERROR)

--- a/functions/FileUploadedFunc/__init__.py
+++ b/functions/FileUploadedFunc/__init__.py
@@ -60,7 +60,8 @@ def main(myblob: func.InputStream):
         
         # Queue message with a random backoff so as not to put the next function under unnecessary load
         queue_client = QueueClient.from_connection_string(azure_blob_connection_string, queue_name, message_encode_policy=TextBase64EncodePolicy())
-        backoff =  random.randint(1, 60)        
+        MAX_SECONDS_HIDE = 180    # number of minutes that a message will be hidden for before being processed by the FR function
+        backoff =  random.randint(1, MAX_SECONDS_HIDE)        
         queue_client.send_message(message_string, visibility_timeout = backoff)  
         statusLog.upsert_document(myblob.name, f'{function_name} - {file_extension} file sent to submit queue. Visible in {backoff} seconds', StatusClassification.DEBUG, State.QUEUED)          
         


### PR DESCRIPTION
enriched error logging to provide more insights into why FR failures occur. Also added a fix to handle errors correctly on submission - these will now log correctly rather than error and retry. Finally increased the max random delay of submitting a file to FR after picking it up to 180 seconds. This will reduce the likelihood of back off requests from FR.

Partial fix for #125 