### PR TITLE
Fix remaining Gamma testing bugs

### DIFF
--- a/app/backend/approaches/chatreadretrieveread.py
+++ b/app/backend/approaches/chatreadretrieveread.py
@@ -197,6 +197,8 @@ class ChatReadRetrieveReadApproach(Approach):
                     + "| "
                     + nonewlines(doc[self.content_field])
                 )
+                # uncomment to debug size of each search result content_field
+                print(f"File{idx}: ", self.num_tokens_from_string(f"File{idx} " + "| " + nonewlines(doc[self.content_field]), "cl100k_base"))
             # add the "FileX" moniker and full file name to the citation lookup
 
             citation_lookup[f"File{idx}"] = {
@@ -267,16 +269,27 @@ class ChatReadRetrieveReadApproach(Approach):
                 history,
                 history[-1]["user"] + "Sources:\n" + content + "\n\n",
                 self.response_prompt_few_shots,
-                max_tokens=self.chatgpt_token_limit
+                max_tokens=self.chatgpt_token_limit - 500
             )
+
+            #Uncomment to debug token usage.
+            #print(messages)
+            #message_string = ""
+            #for message in messages:
+            #    # enumerate the messages and add the role and content elements of the dictoinary to the message_string
+            #    message_string += f"{message['role']}: {message['content']}\n"
+            #print("Content Tokens: ", self.num_tokens_from_string("Sources:\n" + content + "\n\n", "cl100k_base"))
+            #print("System Message Tokens: ", self.num_tokens_from_string(system_message, "cl100k_base"))
+            #print("Few Shot Tokens: ", self.num_tokens_from_string(self.response_prompt_few_shots[0]['content'], "cl100k_base"))
+            #print("Message Tokens: ", self.num_tokens_from_string(message_string, "cl100k_base"))
+            
+
             chat_completion = openai.ChatCompletion.create(
             deployment_id=self.chatgpt_deployment,
             model=self.chatgpt_deployment,
             messages=messages,
             temperature=float(overrides.get("response_temp")) or 0.6,
-            max_tokens=500,
             n=1
-
         )
             
         elif self.model_name == "gpt-4":
@@ -289,6 +302,18 @@ class ChatReadRetrieveReadApproach(Approach):
                 self.response_prompt_few_shots,
                 max_tokens=self.chatgpt_token_limit
             )
+
+            #Uncomment to debug token usage.
+            #print(messages)
+            #message_string = ""
+            #for message in messages:
+            #    # enumerate the messages and add the role and content elements of the dictoinary to the message_string
+            #    message_string += f"{message['role']}: {message['content']}\n"
+            #print("Content Tokens: ", self.num_tokens_from_string("Sources:\n" + content + "\n\n", "cl100k_base"))
+            #print("System Message Tokens: ", self.num_tokens_from_string(system_message, "cl100k_base"))
+            #print("Few Shot Tokens: ", self.num_tokens_from_string(self.response_prompt_few_shots[0]['content'], "cl100k_base"))
+            #print("Message Tokens: ", self.num_tokens_from_string(message_string, "cl100k_base"))
+
             chat_completion = openai.ChatCompletion.create(
             deployment_id=self.chatgpt_deployment,
             model=self.chatgpt_deployment,
@@ -298,14 +323,6 @@ class ChatReadRetrieveReadApproach(Approach):
             n=1
 
         )
-
-       
-
-        #Aparmar.Token Debugging Code. Uncomment to debug token usage.
-        # print(messages)
-        # total_prompt_tokens = sum(len(token.split()) for token in
-        # (system_message + "\n\nSources:\n" + content).split())
-        # print("Total Prompt Tokens:", total_prompt_tokens)
 
         # chat_completion = openai.ChatCompletion.create(
         #     deployment_id=self.chatgpt_deployment,
@@ -427,3 +444,8 @@ class ChatReadRetrieveReadApproach(Approach):
             logging.exception("Unable to parse first page num: " + str(error) + "")
             return "0"
 
+    def num_tokens_from_string(self, string: str, encoding_name: str) -> int:
+        """ Function to return the number of tokens in a text string"""
+        encoding = tiktoken.get_encoding(encoding_name)
+        num_tokens = len(encoding.encode(string))
+        return num_tokens

--- a/app/frontend/src/components/AnalysisPanel/AnalysisPanel.tsx
+++ b/app/frontend/src/components/AnalysisPanel/AnalysisPanel.tsx
@@ -83,7 +83,7 @@ export const AnalysisPanel = ({ answer, activeTab, activeCitation, sourceFile, p
                         ) : (
                             <div>
                             <Separator>Metadata</Separator>
-                            <Label>File Name</Label><span>{activeCitationObj.file_name}</span>
+                            <Label>File Name</Label><Text>{activeCitationObj.file_name}</Text>
                             <Label>File URI</Label><Text>{activeCitationObj.file_uri}</Text>
                             <Label>Title</Label><Text>{activeCitationObj.title}</Text>
                             <Label>Section</Label><Text>{activeCitationObj.section}</Text>

--- a/azure_search/create_skillset.json
+++ b/azure_search/create_skillset.json
@@ -4,7 +4,7 @@
   "skills": [
     {
       "@odata.type": "#Microsoft.Skills.Text.V3.EntityRecognitionSkill",
-      "name": "#1",
+      "name": "EntityRecognition",
       "description": null,
       "context": "/document/content",
       "categories": [
@@ -25,7 +25,7 @@
         },
         {
           "name": "languageCode",
-          "source": "/document/language"
+          "source": "/document/languageWithDefault"
         }
       ],
       "outputs": [
@@ -49,7 +49,7 @@
     },
     {
       "@odata.type": "#Microsoft.Skills.Text.KeyPhraseExtractionSkill",
-      "name": "#2",
+      "name": "KeyPhrases",
       "description": null,
       "context": "/document/content",
       "defaultLanguageCode": "$ACS_KEY_PHRASE_EXTRACTION_SKILL_LANGUAGE",
@@ -62,7 +62,7 @@
         },
         {
           "name": "languageCode",
-          "source": "/document/language"
+          "source": "/document/languageWithDefault"
         }
       ],
       "outputs": [
@@ -74,7 +74,7 @@
     },
     {
       "@odata.type": "#Microsoft.Skills.Text.LanguageDetectionSkill",
-      "name": "#3",
+      "name": "LanguageDetection",
       "description": null,
       "context": "/document",
       "defaultCountryHint": null,
@@ -93,8 +93,20 @@
       ]
     },
     {
+      "@odata.type": "#Microsoft.Skills.Util.ConditionalSkill",
+      "name": "LangaugeWithDefault",
+      "description": null,
+      "context": "/document",
+      "inputs": [
+          { "name": "condition", "source": "= $(/document/language) == '(Unknown)'" },
+          { "name": "whenTrue", "source": "= '$ACS_TEXT_TRANSLATION_SKILL_TO_LANGUAGE'" },
+          { "name": "whenFalse", "source": "= $(/document/language)" }
+      ],
+      "outputs": [ { "name": "output", "targetName": "languageWithDefault" } ]
+    },
+    {
       "@odata.type": "#Microsoft.Skills.Text.TranslationSkill",
-      "name": "#4",
+      "name": "Translation",
       "description": null,
       "context": "/document/content",
       "defaultFromLanguageCode": null,
@@ -115,7 +127,7 @@
     },
     {
       "@odata.type": "#Microsoft.Skills.Text.PIIDetectionSkill",
-      "name": "#5",
+      "name": "PIIDetection",
       "description": null,
       "context": "/document/content",
       "defaultLanguageCode": "$ACS_PII_DETECTION_SKILL_LANGUAGE",
@@ -132,7 +144,7 @@
         },
         {
           "name": "languageCode",
-          "source": "/document/language"
+          "source": "/document/languageWithDefault"
         }
       ],
       "outputs": [
@@ -148,7 +160,7 @@
     },
     {
       "@odata.type": "#Microsoft.Skills.Text.SplitSkill",
-      "name": "#6",
+      "name": "TextSplit",
       "textSplitMode": "pages",
       "maximumPageLength": 5000,
       "defaultLanguageCode": "$ACS_TEXT_SPLITTING_SKILL_LANGUAGE",
@@ -160,7 +172,7 @@
         },
         {
           "name": "languageCode",
-          "source": "/document/language"
+          "source": "/document/languageWithDefault"
         }
       ],
       "outputs": [
@@ -172,7 +184,7 @@
     },
     {
       "@odata.type": "#Microsoft.Skills.Util.DocumentExtractionSkill",
-      "name": "#7",
+      "name": "DocExtraction",
       "parsingMode": "default",
       "dataToExtract": "contentAndMetadata",
       "configuration": {
@@ -200,7 +212,7 @@
     },
     {
       "@odata.type": "#Microsoft.Skills.Vision.OcrSkill",
-      "name": "#8",
+      "name": "OCR",
       "description": null,
       "context": "/document/normalized_images/*",
       "textExtractionAlgorithm": null,
@@ -226,7 +238,7 @@
     },
     {
       "@odata.type": "#Microsoft.Skills.Vision.ImageAnalysisSkill",
-      "name": "#9",
+      "name": "ImageAnalysis",
       "description": null,
       "context": "/document/normalized_images/*",
       "defaultLanguageCode": "$ACS_IMAGE_ANALYSIS_SKILL_LANGUAGE",
@@ -254,7 +266,7 @@
     },
     {
       "@odata.type": "#Microsoft.Skills.Text.MergeSkill",
-      "name": "#10",
+      "name": "MergeContentwImageTags",
       "description": "Create merged_content, which includes all the image caption, ocr text, image tags and the content field.",
       "context": "/document",
       "insertPreTag": " ",
@@ -278,7 +290,7 @@
     },
     {
       "@odata.type": "#Microsoft.Skills.Text.MergeSkill",
-      "name": "#11",
+      "name": "MergewOCRText",
       "description": "Create merged_imgCaption_ocrtext_imgTags, which includes all the tags added to the image caption and ocr text.",
       "context": "/document",
       "insertPreTag": " ",
@@ -302,7 +314,7 @@
     },
     {
       "@odata.type": "#Microsoft.Skills.Text.MergeSkill",
-      "name": "#12",
+      "name": "MergewOCRText2",
       "description": "Create merged_imgCaption_ocrtext, which includes the image caption and any ocr text.",
       "context": "/document",
       "insertPreTag": " ",

--- a/docs/features/features.md
+++ b/docs/features/features.md
@@ -28,6 +28,8 @@ For more details on how we process each document type click on on the document t
 
 We also log the status of the pre-processing in Azure Cosmos DB. View our [Status Logging](../../functions/shared_code/status_log.md) page for more details.
 
+Additionally, there are many configuration values that can be altered to effect the performance and behaviors of the chunking patterns. More details on the deployment configurations can be found in our [Function Flow documentation](../functions_flow.md)
+
 ## User Experience
 
 The end user leverages the web interface as the primary method to engage with the IA Accelerator, and the Azure OpenAI service. The user interface is very similar to that of the OpenAI ChatGPT interface, though it provides different and additional functionality which is outlined below.

--- a/docs/functions_flow.md
+++ b/docs/functions_flow.md
@@ -26,7 +26,7 @@ There are a number of settings that are configured during deployment, but which 
 
 Setting | Description
 --- | ---
-CHUNK_TARGET_SIZE | The number of tokens the function targets as the maximum per chunk generated
+CHUNK_TARGET_SIZE | The number of tokens the function targets as the maximum per chunk text content to be generated. Additional metadata are added to the chunk JSON files as they are created that add roughly 180-200 tokens to the overall size of the chunk JSON file that gets indexed by Azure Cognitive Search. So we recommend setting the **CHUNK_TARGET_SIZE** to your overall size target minus 200 tokens. 
 MAX_SECONDS_HIDE_ON_UPLOAD | The maximum number of seconds a message will be hidden when initially submitting to the process. The actual time a message is invisible is a random value from 0 to this cap. This spreads out initial processing so as not to hit a throttling event unnecessarily
 MAX_SUBMIT_REQUEUE_COUNT | The maximum number of times the process will try to process a PDF through Form Recognizer
 PDF_SUBMIT_QUEUE_BACKOFF | The number of seconds a message will remain invisible after resubmitting to the queue due to throttling during submitting to Form Recognizer

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -51,7 +51,8 @@ param searchIndexName string = 'all-files-index'
 param chatGptDeploymentName string = 'chat'
 param chatGptModelName string = 'gpt-35-turbo'
 param chatGptDeploymentCapacity int = 30
-param chunkTargetSize string = '750'
+// metadata in our chunking strategy adds about 180 tokens to the size of the chunk, our default target size is 750 tokens so the prameter is set to 570
+param chunkTargetSize string = '570' 
 param targetPages string = 'ALL'
 param formRecognizerApiVersion string = '2022-08-31'
 param pdfSubmitQueue string = 'pdf-submit-queue'


### PR DESCRIPTION
In this PR we have fixed a few bugs found in Gamma validation testing:
- "Too many tokens" error when targeting gpt-3.5-turbo. This was caused by the "max token" configuration on the Azure Functions no accounting for the extra tokens added from metadata in the document chunk JSON files. We adjusted the configuration value and updated the documentation to reflect the new calculations
- During search indexing many of the document chunks were not being processed with an error about "(Unknown)" language codes. It turns out that Azure Cognitive Services for Language do not return an error when a specific language cannot be determined, but rather returns a 200 success with a language value of "(Unknown)". We made an adjustment in the search skillsets to add a conditional check for an "(Unknown)" return and replace it with the default translation language code. 
- Fixed the File Name controls on the citation UX to be type "Text" instead of "Span" to match the other fields on the same UX page. 