### PR TITLE
Geearl/5977 container app service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ build-deploy: build extract-env deploy-webapp ##Build and Deploy the Webapp
 build: ## Build application code
 	@./scripts/build.sh
 
-build-containers:
+build-containers: extract-env
 	@./app/enrichment/docker-build.sh
 
 infrastructure: check-subscription ## Deploy infrastructure

--- a/app/enrichment/docker-build.sh
+++ b/app/enrichment/docker-build.sh
@@ -6,13 +6,7 @@ set -e
 
 figlet "Build Docker Containers"
 
-
 image_name="enrichment-app"
-CONTAINER_REGISTRY_NAME_SUFFIX="azurecr.io"
-if $IS_USGOV_DEPLOYMENT; then 
-  CONTAINER_REGISTRY_NAME_SUFFIX="azurecr.us"
-fi
-echo "IS_USGOV_DEPLOYMENT: "$IS_USGOV_DEPLOYMENT
 
 # Get the required directories of the project
 APP_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
@@ -20,8 +14,13 @@ SCRIPTS_DIR="$(realpath "$APP_DIR/../../scripts")"
 
 # Get the directory that this script is in
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-#source "${SCRIPTS_DIR}"/load-env.sh
 source "${SCRIPTS_DIR}/environments/infrastructure.env"
+
+# Determine if this is a gov deployment
+CONTAINER_REGISTRY_NAME_SUFFIX="azurecr.io"
+if $IS_USGOV_DEPLOYMENT; then 
+  CONTAINER_REGISTRY_NAME_SUFFIX="azurecr.us"
+fi
 
 # Build the container
 echo "Building container"

--- a/infra/core/host/appservicecontainer.bicep
+++ b/infra/core/host/appservicecontainer.bicep
@@ -90,18 +90,6 @@ identity: {
 }
 properties: {
   enabled: true
-    hostNameSslStates: [
-      {
-        name: '${appServiceName}.azurewebsites.net'
-        sslState: 'Disabled'
-        hostType: 'Standard'
-      }
-      {
-        name: '${appServiceName}.scm.azurewebsites.net'
-        sslState: 'Disabled'
-        hostType: 'Repository'
-      }
-    ]
     serverFarmId: appServicePlan.id
     siteConfig: {
       numberOfWorkers: 1

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -637,3 +637,4 @@ output AZURE_SUBSCRIPTION_ID string = subscriptionId
 output CONTAINER_REGISTRY_ID string = containerRegistry.outputs.id
 output CONTAINER_REGISTRY_NAME string = containerRegistry.outputs.name
 output CONTAINER_APP_SERVICE string = appServiceContainer.outputs.name
+output IS_USGOV_DEPLOYMENT bool = isGovCloudDeployment

--- a/scripts/inf-create.sh
+++ b/scripts/inf-create.sh
@@ -9,7 +9,8 @@ printInfo() {
 }
 
 figlet Infrastructure
- 
+
+
 # Get the directory that this script is in
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source "${DIR}/load-env.sh"

--- a/scripts/json-to-env.sh
+++ b/scripts/json-to-env.sh
@@ -80,7 +80,11 @@ jq -r  '
         {
             "path": "containeR_APP_SERVICE",
             "env_var": "CONTAINER_APP_SERVICE"
-        }       
+        },       
+        {
+            "path": "iS_USGOV_DEPLOYMENT",
+            "env_var": "IS_USGOV_DEPLOYMENT"
+        }               
     ]
         as $env_vars_to_extract
     |


### PR DESCRIPTION
This PR add additional infrastructure to the container capability. Specifically:
- 5977: creation of a new app service and service plan to host the container pushed to ACR
- 5978: Point the app service at the container image in ACR
- 5979: adapting the service plan which provides compute for the container to autoscale based upon a rule that checks the number of messages in a queue