### PR TITLE
hot fix for missing subtitle in non-pdf

### DIFF
--- a/functions/shared_code/utilities.py
+++ b/functions/shared_code/utilities.py
@@ -289,6 +289,7 @@ class Utilities:
                     "type": "text", 
                     "text": tag.get_text(strip=True),
                     "title": title,
+                    'subtitle': '',
                     "section": section,
                     "page_number": 1                
                     })
@@ -297,6 +298,7 @@ class Utilities:
                     "type": "table", 
                     "text": str(tag),
                     "title": title,
+                    'subtitle': '',
                     "section": section,
                     "page_number": 1                
                     })


### PR DESCRIPTION
hotfix to add in the required subtitle key-value for non-pdf. This was resulting in an error downstream where it was required