### PR TITLE
Model check Fix

### DIFF
--- a/app/backend/approaches/chatreadretrieveread.py
+++ b/app/backend/approaches/chatreadretrieveread.py
@@ -98,7 +98,7 @@ class ChatReadRetrieveReadApproach(Approach):
         self.content_field = content_field
         self.blob_client = blob_client
         self.query_term_language = query_term_language
-        self.chatgpt_token_limit = get_token_limit(chatgpt_deployment)
+        self.chatgpt_token_limit = get_token_limit(model_name)
 
         openai.api_base = 'https://' + oai_service_name + '.openai.azure.com/'
         openai.api_type = 'azure'


### PR DESCRIPTION
We should be leveraging model name to check token length, not deployment name. 