### PR TITLE
Fix for Deployment Name

### DIFF
--- a/app/backend/approaches/chatreadretrieveread.py
+++ b/app/backend/approaches/chatreadretrieveread.py
@@ -125,7 +125,7 @@ class ChatReadRetrieveReadApproach(Approach):
         # STEP 1: Generate an optimized keyword search query based on the chat history and the last question
         messages = self.get_messages_from_history(
             query_prompt,
-            self.chatgpt_deployment,
+            self.model_name,
             history,
             user_q,
             self.query_prompt_few_shots,
@@ -135,7 +135,7 @@ class ChatReadRetrieveReadApproach(Approach):
         chat_completion = openai.ChatCompletion.create(
 
             deployment_id=self.chatgpt_deployment,
-            model=self.chatgpt_deployment,
+            model=self.model_name,
             messages=messages,
             temperature=0.0,
             max_tokens=32,
@@ -267,7 +267,7 @@ class ChatReadRetrieveReadApproach(Approach):
         if self.model_name.startswith("gpt-35-turbo"):
             messages = self.get_messages_from_history(
                 system_message,
-                self.chatgpt_deployment,
+                self.model_name,
                 history,
                 history[-1]["user"] + "Sources:\n" + content + "\n\n",
                 self.response_prompt_few_shots,
@@ -288,7 +288,7 @@ class ChatReadRetrieveReadApproach(Approach):
 
             chat_completion = openai.ChatCompletion.create(
             deployment_id=self.chatgpt_deployment,
-            model=self.chatgpt_deployment,
+            model=self.model_name,
             messages=messages,
             temperature=float(overrides.get("response_temp")) or 0.6,
             n=1
@@ -298,7 +298,7 @@ class ChatReadRetrieveReadApproach(Approach):
             messages = self.get_messages_from_history(
                 "Sources:\n" + content + "\n\n" + system_message,
                 # system_message + "\n\nSources:\n" + content,
-                self.chatgpt_deployment,
+                self.model_name,
                 history,
                 history[-1]["user"],
                 self.response_prompt_few_shots,
@@ -318,7 +318,7 @@ class ChatReadRetrieveReadApproach(Approach):
 
             chat_completion = openai.ChatCompletion.create(
             deployment_id=self.chatgpt_deployment,
-            model=self.chatgpt_deployment,
+            model=self.model_name,
             messages=messages,
             temperature=float(overrides.get("response_temp")) or 0.6,
             max_tokens=1024,
@@ -328,7 +328,7 @@ class ChatReadRetrieveReadApproach(Approach):
 
         # chat_completion = openai.ChatCompletion.create(
         #     deployment_id=self.chatgpt_deployment,
-        #     model=self.chatgpt_deployment,
+        #     model=self.model_name,
         #     messages=messages,
         #     temperature=float(overrides.get("response_temp")) or 0.6,
         #     max_tokens=1024,


### PR DESCRIPTION
Fix a few more places that we are assuming the deployment_name is the same as the model name.  Many customers have existing Deployments where the name is different than the model.