### PR TITLE
Geearl/6053 large files missing chunks

### DIFF
--- a/app/enrichment/app.py
+++ b/app/enrichment/app.py
@@ -330,7 +330,7 @@ def poll_queue() -> None:
                 embedding_data = embedding['data']                   
                 
                 index_chunk = {}
-                index_chunk['id'] = statusLog.encode_document_id(chunk_dict['file_uri'])
+                index_chunk['id'] = statusLog.encode_document_id(chunk.name)
                 index_chunk['processed_datetime'] = f"{chunk_dict['processed_datetime']}+00:00"
                 index_chunk['file_name'] = chunk_dict["file_name"]
                 index_chunk['file_uri'] = chunk_dict["file_uri"]


### PR DESCRIPTION
This PR fixes the issue with only a single chunk reaching the index. This was because every chunk was given the same id, based upon the document name, rather than the chunk name. Hence each chunk, as being passed to the index was overwriting the previous one.