### PR TITLE
Updating the GPT-35-Turbo-16K capacity to default

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -51,7 +51,7 @@ param searchIndexName string = 'all-files-index'
 param chatGptDeploymentName string = 'chat'
 param chatGptModelName string = 'gpt-35-turbo-16k'
 param chatGptModelVersion string = '0613'
-param chatGptDeploymentCapacity int = 720
+param chatGptDeploymentCapacity int = 240
 // metadata in our chunking strategy adds about 180-200 tokens to the size of the chunks, 
 // our default target size is 750 tokens so the chunk files that get indexed will be around 950 tokens each
 param chunkTargetSize string = '750' 


### PR DESCRIPTION
Setting to the default capacity limit for gpt-3.5-turbo-16k. 
This will fix the deployment issue #282 faced by the users.
