### PR TITLE
Geearl/6184 function timeout

### DIFF
--- a/functions/host.json
+++ b/functions/host.json
@@ -16,5 +16,5 @@
     "dynamicConcurrencyEnabled": true,
     "snapshotPersistenceEnabled": true
   },
-  "functionTimeout": "00:29:59"
+  "functionTimeout": "01:00:00"
 }


### PR DESCRIPTION
Simple PR to increase function timeout to 1 hour from 30 minutes, to give more of a chance for the functions to complete when under large stress