### PR TITLE
Resolve startup failure with aoai model usage

### DIFF
--- a/app/enrichment/model_handling.py
+++ b/app/enrichment/model_handling.py
@@ -21,6 +21,9 @@ def load_models():
     model_info = {}
 
     for model_name in models_to_download:
+        # Ignore AOAI models as they are downloaded elsewhere
+        if model_name.startswith("azure-openai"):
+            continue
         model = SentenceTransformer(model_name)
         sanitized_model_name = re.sub(r'[^a-zA-Z0-9_\-.]', '_', model_name)
         model.save(os.path.join(models_path,sanitized_model_name))


### PR DESCRIPTION
Ignore AOAI embedding model in model handler with hugginface as it is included by default elsewhere.