### PR TITLE
Update `local.env.example` to match deployment guide for required fields

### DIFF
--- a/scripts/environments/local.env.example
+++ b/scripts/environments/local.env.example
@@ -1,21 +1,24 @@
+# Values that are required below are marked accordingly. Depending on your selections additional values may be required. 
+# Please see our deployment guide for more information at ./docs/deployment/deployment.md#configure-env-files
+
 # Region to deploy into when running locally.
 # This is set by the Azure Pipeline for other environments.
-export LOCATION="westeurope"
-export WORKSPACE="myworkspace"
-export SUBSCRIPTION_ID=""
-export TENANT_ID=""
-export IS_USGOV_DEPLOYMENT=false
+export LOCATION="westeurope" # Required
+export WORKSPACE="myworkspace" # Required
+export SUBSCRIPTION_ID="" # Required
+export TENANT_ID="" # Required
+export IS_USGOV_DEPLOYMENT=false # Required
 
 # Use this setting to determine whether a user needs to be granted explicit access to the website via an
 # Azure AD Enterprise Application membership (true) or allow the website to be available to anyone in the Azure tenant (false). Defaults to false.
 # If set to true, A tenant level administrator will be required to grant the implicit grant workflow for the Azure AD App Registration manually.
-export REQUIRE_WEBSITE_SECURITY_MEMBERSHIP=false
+export REQUIRE_WEBSITE_SECURITY_MEMBERSHIP=false # Required
 
 # Uncomment this if you want to avoid the "are you sure?" prompt when applying TF changes
 # export SKIP_PLAN_CHECK=1
 
 # If using an existing deployment of Azure OpenAI, set the USE_EXISTING_AOAI to true and fill in the following values
-export USE_EXISTING_AOAI=false
+export USE_EXISTING_AOAI=false # Required
 export AZURE_OPENAI_RESOURCE_GROUP=""
 export AZURE_OPENAI_SERVICE_NAME=""
 export AZURE_OPENAI_SERVICE_KEY=""
@@ -30,7 +33,7 @@ export AZURE_OPENAI_CHATGPT_DEPLOYMENT=""
 
 
 # To use Azure OpenAI Embeddings, set the following properties:
-export USE_AZURE_OPENAI_EMBEDDINGS=true
+export USE_AZURE_OPENAI_EMBEDDINGS=true # Required
 export AZURE_OPENAI_EMBEDDING_MODEL="text-embedding-ada-002"
 
 # If you prefer an open-source Embedding model, use below section to set your preferred model:
@@ -64,14 +67,16 @@ export AZURE_OPENAI_EMBEDDING_MODEL="text-embedding-ada-002"
 # ...then you will need to set the following values to the Azure OpenAI model you want to use. 
 export AZURE_OPENAI_CHATGPT_MODEL_NAME=""
 export AZURE_OPENAI_CHATGPT_MODEL_VERSION=""
+#-------------------------------------------------------------------------------------------------#
+
 # If you have limited capacity in your subscription, you can set the following to limit the deployment capacity.
-export AZURE_OPENAI_CHATGPT_MODEL_CAPACITY="240"
+export AZURE_OPENAI_CHATGPT_MODEL_CAPACITY="240" # Required
 
 # If your deployment requires a warning banner and footer, please set this variable.
 export CHAT_WARNING_BANNER_TEXT=""
 
 # A pointer to a supported language ENV file located in the ./languages folder.
-export DEFAULT_LANGUAGE="en-US"
+export DEFAULT_LANGUAGE="en-US" # Required
 
 # If you are deploying this for a customer, you can optionally set the following values to track usage of the accelerator.
 # This uses the pattern of Customer Usage Attribution, more info can be found at https://learn.microsoft.com/en-us/partner-center/marketplace/azure-partner-customer-usage-attribution 


### PR DESCRIPTION
Added reference to deployment guide to `local.env.example` and marked fields as required to match with deployment guide. 