### PR TITLE
Update costestimator.md to reflect current release

### DIFF
--- a/docs/costestimator.md
+++ b/docs/costestimator.md
@@ -10,7 +10,7 @@ The Azure pricing calculator helps estimate costs by considering the amount of d
 ---
 ### Azure Services
 
-The following list of Azure Services will be deployed for IA Accelerator, version 0.4 gamma:
+The following list of Azure Services will be deployed for IA Accelerator, version 0.4 delta:
 
 - App Service [:link:](https://azure.microsoft.com/en-ca/pricing/details/app-service/linux/)
 - Azure Function(App Service plan) [:link:](https://azure.microsoft.com/en-ca/pricing/details/functions/#pricing)


### PR DESCRIPTION
Updated the Azure Services section which starts with "The following list of Azure Services will be deployed for IA Accelerator, version 0.4 gamma", replacing the word "gamma" with "delta"