### PR TITLE
Update Document Intelligence to latest GA to resolve unicode issues

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -65,7 +65,7 @@ param chatGptDeploymentCapacity int = 240
 // our default target size is 750 tokens so the chunk files that get indexed will be around 950 tokens each
 param chunkTargetSize string = '750'
 param targetPages string = 'ALL'
-param formRecognizerApiVersion string = '2022-08-31'
+param formRecognizerApiVersion string = '2023-07-31'
 param queryTermLanguage string = 'English'
 param isGovCloudDeployment bool = contains(location, 'usgov')
 


### PR DESCRIPTION
Update Document Intelligence to latest GA to resolve unicode issues in table splitting.

Hidden unicode characters in some documents cause issue with Document Intelligence in version 2022-08-31.
This can be seen in the FR result and Document Map objects creating phantom spans for a table section.

![image](https://github.com/microsoft/PubSec-Info-Assistant/assets/17028127/e528e874-4ce2-4098-a0b9-1aaa2d7090eb)

![image](https://github.com/microsoft/PubSec-Info-Assistant/assets/17028127/a8c5b2ff-9f18-42ae-b6cd-0e7c6ccb791e)

Updating to the latest GA resolves this issue.

![image](https://github.com/microsoft/PubSec-Info-Assistant/assets/17028127/56971a4f-dd09-4c01-ae16-b26093116d55)

![image](https://github.com/microsoft/PubSec-Info-Assistant/assets/17028127/58ef3015-2f76-4a96-b5c3-62568d45ff2f)

