### PR TITLE
Remove media_service and avam modules from BICEP

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -40,8 +40,6 @@ param applicationInsightsName string = ''
 param backendServiceName string = ''
 param enrichmentServiceName string = ''
 param functionsAppName string = ''
-param mediaServiceName string = ''
-param videoIndexerName string = ''
 param searchServicesName string = ''
 param searchServicesSkuName string = 'standard'
 param storageAccountName string = ''
@@ -544,30 +542,6 @@ module functions 'core/function/function.bicep' = {
     cosmosdb
     kvModule
   ]
-}
-
-// Media Service
-module media_service 'core/video_indexer/media_service.bicep' = {
-  name: 'media_service'
-  scope: rg
-  params: {
-    name: !empty(mediaServiceName) ? mediaServiceName : '${prefix}${abbrs.mediaService}${randomString}'
-    location: location
-    tags: tags
-    storageAccountID: storageMedia.outputs.id
-  }
-}
-
-// AVAM Service
-module avam 'core/video_indexer/video_indexer.bicep' = {
-  name: 'avam'
-  scope: rg
-  params: {
-    name: !empty(videoIndexerName) ? videoIndexerName : '${prefix}${abbrs.videoIndexer}${randomString}'
-    location: location
-    tags: tags
-    mediaServiceAccountResourceId: media_service.outputs.id
-  }
 }
 
 // USER ROLES


### PR DESCRIPTION
This is a temporary fix due to recent changes related to the retirement of Azure Media Services. Information Assistant uses Azure Video Indexer that depends on Azure Media Services. Changes are required to support the AMS retirement that are not yet available in BICEP. Details on the changes can be found at https://learn.microsoft.com/en-us/azure/azure-video-indexer/azure-video-indexer-azure-media-services-retirement-announcement 

Fixes #501