### PR TITLE
Add "All" option to dropdownTimespanOptions

### DIFF
--- a/app/frontend/src/components/FileStatus/FileStatus.tsx
+++ b/app/frontend/src/components/FileStatus/FileStatus.tsx
@@ -23,6 +23,7 @@ const dropdownTimespanOptions = [
     { key: '24hours', text: '24 hours' },
     { key: '7days', text: '7 days' },
     { key: '30days', text: '30 days' },
+    { key: '-1days', text: 'All' },
   ];
 
 const dropdownFileStateOptions = [
@@ -92,6 +93,9 @@ export const FileStatus = ({ className }: Props) => {
                 break;
             case "30days":
                 timeframe = 720;
+                break;
+            case "-1days":
+                timeframe = -1;
                 break;
             default:
                 timeframe = 4;


### PR DESCRIPTION
This PR adds an option 'All' under the timespan filter in the upload status page. The intent is to transform this page into a document management page, rather than just viewing status of recent uploads. A scenario could be to delete all files in a particular folder that was uploaded 3 months ago. This would now support that idea.