### PR TITLE
Geearl/7110 status icons

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -280,9 +280,9 @@ async def get_all_upload_status(request: Request):
         # retrieve tags for each file
          # Initialize an empty list to hold the tags
         items = []              
-        cosmos_client = CosmosClient(url=tagsHelper._url, credential=tagsHelper._key)
-        database = cosmos_client.get_database_client(tagsHelper._database_name)
-        container = database.get_container_client(tagsHelper._container_name)
+        cosmos_client = CosmosClient(url=statusLog._url, credential=statusLog._key)     
+        database = cosmos_client.get_database_client(statusLog._database_name)               
+        container = database.get_container_client(statusLog._container_name)         
         query_string = "SELECT DISTINCT VALUE t FROM c JOIN t IN c.tags"
         items = list(container.query_items(
             query=query_string,

--- a/app/frontend/src/components/FileStatus/DocumentsDetailList.module.css
+++ b/app/frontend/src/components/FileStatus/DocumentsDetailList.module.css
@@ -97,6 +97,9 @@
   text-align: center;
 }
 
-.refreshicon {
-  fill: #606060; /* Mid-dark grey for SVG icons */
+.refreshtext {
+  font-size: 0.8em; /* Smaller text size, adjust as needed */
 }
+
+.refreshicon {
+  fill: #606060; /* Mid-dark grey for SVG icons */}

--- a/app/frontend/src/components/FileStatus/DocumentsDetailList.module.css
+++ b/app/frontend/src/components/FileStatus/DocumentsDetailList.module.css
@@ -70,3 +70,33 @@
   max-width: 400px;  /* Adjust the width as needed */
   overflow-y: auto;  /* This enables vertical scrolling */
 }
+
+.buttonsContainer {
+  display: flex;
+  align-items: center; /* Align items vertically in the center */
+  justify-content: flex-start; /* Align items to the start (left) of the container */
+}
+
+.refresharea {
+  display: flex;
+  align-items: center; /* Vertically center the text with the icon */
+  justify-content: center; /* Horizontally center the text and the icon */
+  border: 2px solid #606060; /* Mid-dark grey border */
+  border-radius: 10px; /* Adjust for desired curvature of corners */
+  background-color: transparent; /* Transparent background */
+  cursor: pointer; /* Change cursor to pointer on hover */
+  padding: 5px 10px; /* Add some padding inside the button */
+  color: #606060; /* Mid-dark grey text */
+}
+
+.divSpacing {
+  margin: 10px; /* Adjust as needed */
+}
+
+.centeredText {
+  text-align: center;
+}
+
+.refreshicon {
+  fill: #606060; /* Mid-dark grey for SVG icons */
+}

--- a/app/frontend/src/components/FileStatus/DocumentsDetailList.tsx
+++ b/app/frontend/src/components/FileStatus/DocumentsDetailList.tsx
@@ -298,13 +298,12 @@ export const DocumentsDetailList = ({ items, onFilesSorted, onRefresh }: Props) 
             onColumnClick: onColumnClick,
             data: 'string',
             onRender: (item: IDocument) => (
-                <TooltipHost content={`${item.state} `}>
-                    <span onClick={() => onStateColumnClick(item)} style={{ cursor: 'pointer', color:'blue', textDecoration:'underline' }}>
-                        {item.state}
+                <TooltipHost content={`${item.state_description} `}>
+                    <span onClick={() => onStateColumnClick(item)} style={{ cursor: 'pointer' }}>
+                        {item.state_description}
                     </span>
-                    {item.state === 'Error' && <a href="javascript:void(0);" onClick={() => retryErroredFile(item)}> - Retry File</a>}
                 </TooltipHost>
-            ), 
+            ),
             isPadded: true,
         },
         {
@@ -483,26 +482,6 @@ export const DocumentsDetailList = ({ items, onFilesSorted, onRefresh }: Props) 
                     <StatusContent item={value} />
                     </div>
                 </Panel>
-                
-            {/* <Dialog
-                hidden={!stateDialogVisible}
-                onDismiss={() => setStateDialogVisible(false)}
-                dialogContentProps={{
-                    type: DialogType.normal,
-                    title: 'State Details',
-                    closeButtonAriaLabel: 'Close',
-                }}
-                modalProps={{
-                    styles: dialogStyles,
-                }}
-            >
-                <div className="scrollableDialogContent" ref={scrollableContentRef}>
-                    {stateDialogContent}
-                </div>
-                <DialogFooter>
-                    <PrimaryButton onClick={() => setStateDialogVisible(false)} text="OK" />
-                </DialogFooter>
-            </Dialog> */}
         </div>
     );
 }

--- a/app/frontend/src/components/FileStatus/DocumentsDetailList.tsx
+++ b/app/frontend/src/components/FileStatus/DocumentsDetailList.tsx
@@ -1,19 +1,18 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import React, { useState, useEffect, useRef, useLayoutEffect } from "react";
-import { Delete24Regular,
-    Send24Regular,
-    ArrowClockwise24Filled
-    } from "@fluentui/react-icons";
-
+import React, { forwardRef, 
+    useImperativeHandle, 
+    useState, 
+    useEffect, 
+    useRef
+    } from "react";
 import { DetailsList, 
     DetailsListLayoutMode, 
     SelectionMode, 
     IColumn, 
     Selection, 
     TooltipHost,
-    Button,
     Dialog, 
     DialogType, 
     DialogFooter, 
@@ -25,7 +24,6 @@ import { retryFile } from "../../api";
 import styles from "./DocumentsDetailList.module.css";
 import { deleteItem, DeleteItemRequest, resubmitItem, ResubmitItemRequest } from "../../api";
 import { StatusContent } from "../StatusContent/StatusContent";
-
 
 export interface IDocument {
     key: string;
@@ -54,9 +52,21 @@ interface Props {
     onRefresh: () => void; // Add this line
 }
 
-export const DocumentsDetailList = ({ items, onFilesSorted, onRefresh }: Props) => {
+export interface IDocumentsDetailList {
+    handleDeleteClick: () => void;
+    handleResubmitClick: () => void;
+}
+
+
+
+export const DocumentsDetailList = forwardRef(({ items, onFilesSorted, onRefresh }: Props, ref) => {
 
     const itemsRef = useRef(items);
+
+    useImperativeHandle(ref, () => ({
+    handleDeleteClick,
+    handleResubmitClick
+}));
 
     const onColumnClick = (ev: React.MouseEvent<HTMLElement>, column: IColumn): void => {
         const newColumns: IColumn[] = columns.slice();
@@ -88,6 +98,11 @@ export const DocumentsDetailList = ({ items, onFilesSorted, onRefresh }: Props) 
     function onItemInvoked(item: any): void {
         alert(`Item invoked: ${item.name}`);
     }
+
+    useImperativeHandle(ref, () => ({
+        handleDeleteClick,
+        handleResubmitClick
+    }));
 
     const [itemList, setItems] = useState<IDocument[]>(items);
     function retryErroredFile(item: IDocument): void {
@@ -224,7 +239,9 @@ export const DocumentsDetailList = ({ items, onFilesSorted, onRefresh }: Props) 
     // State detail dialog
     const [value, setValue] = useState('Initial value');
     const [stateDialogVisible, setStateDialogVisible] = useState(false);
-    
+    const [stateDialogContent, setStateDialogContent] = useState<React.ReactNode>(null);
+    const scrollableContentRef = useRef<HTMLDivElement>(null);
+
     const refreshProp = (item: any) => {
         setValue(item);
       };
@@ -238,21 +255,6 @@ export const DocumentsDetailList = ({ items, onFilesSorted, onRefresh }: Props) 
             // Handle error here, perhaps show an error message to the user
         }
     };
-
-    const dialogStyles = {
-        main: {
-            width: '400px',  // Set the width to 400 pixels
-            maxWidth: '400px', // Set the maximum width to 400 pixels
-            maxHeight: '400px', // Set the maximum height to 400 pixels
-            overflowY: 'auto', // Enable vertical scrolling for the entire dialog if needed
-        },
-    };
-
-
-    useEffect(() => {
-        // Scroll to the top when the dialog opens
-        window.scrollTo({ top: 0, left: 0, behavior: 'smooth' });
-    }, []);
 
     const [columns, setColumns] = useState<IColumn[]> ([
         {
@@ -396,22 +398,6 @@ export const DocumentsDetailList = ({ items, onFilesSorted, onRefresh }: Props) 
 
     return (
         <div>
-            {/* <Button text="Delete" onClick={handleDeleteClick} style={{ marginRight: '10px' }} />
-            <Button text="Resubmit" onClick={handleResubmitClick} /> */}
-            <div className={styles.buttonsContainer}>
-                <div className={`${styles.refresharea} ${styles.divSpacing}`} onClick={onRefresh} aria-label="Refresh">
-                    <ArrowClockwise24Filled className={styles.refreshicon} />
-                    <span className={`${styles.refreshtext} ${styles.centeredText}`}>Refresh</span>
-                </div>
-                <div className={`${styles.refresharea} ${styles.divSpacing}`} onClick={handleDeleteClick} aria-label="Delete">
-                    <Delete24Regular className={styles.refreshicon} />
-                    <span className={`${styles.refreshtext} ${styles.centeredText}`}>Delete</span>
-                </div>
-                <div className={`${styles.refresharea} ${styles.divSpacing}`} onClick={handleResubmitClick} aria-label="Resubmit">
-                    <Send24Regular className={styles.refreshicon} />
-                    <span className={`${styles.refreshtext} ${styles.centeredText}`}>Resubmit</span>
-                </div>
-            </div>
             {/* Dialog for delete confirmation */}
             <Dialog
                 hidden={!isDeleteDialogVisible}
@@ -484,4 +470,4 @@ export const DocumentsDetailList = ({ items, onFilesSorted, onRefresh }: Props) 
                 </Panel>
         </div>
     );
-}
+})

--- a/app/frontend/src/components/FileStatus/DocumentsDetailList.tsx
+++ b/app/frontend/src/components/FileStatus/DocumentsDetailList.tsx
@@ -2,6 +2,9 @@
 // Licensed under the MIT license.
 
 import React, { useState, useEffect, useRef, useLayoutEffect } from "react";
+import { Delete24Regular,
+    Send24Regular
+    } from "@fluentui/react-icons";
 
 import { DetailsList, 
     DetailsListLayoutMode, 
@@ -16,15 +19,12 @@ import { DetailsList,
     PrimaryButton,
     DefaultButton, 
     Panel,
-    PanelType} from "@fluentui/react";
- import { Resizable, ResizableBox } from "react-resizable";
+    PanelType,} from "@fluentui/react";
 import { retryFile } from "../../api";
 import styles from "./DocumentsDetailList.module.css";
 import { deleteItem, DeleteItemRequest, resubmitItem, ResubmitItemRequest } from "../../api";
 import { StatusContent } from "../StatusContent/StatusContent";
-import Draggable from "react-draggable";
-// import Resizable from "re-resizable";
-// import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
+
 
 export interface IDocument {
     key: string;
@@ -178,7 +178,6 @@ export const DocumentsDetailList = ({ items, onFilesSorted}: Props) => {
         setNotification({ show: true, message: 'Processing deletion. Hit \'Refresh\' to track progress' });
     };
     
-
     // Function to handle the delete button click
     const handleDeleteClick = () => {
         showDeleteConfirmation();
@@ -222,21 +221,7 @@ export const DocumentsDetailList = ({ items, onFilesSorted}: Props) => {
     // State detail dialog
     const [value, setValue] = useState('Initial value');
     const [stateDialogVisible, setStateDialogVisible] = useState(false);
-    const [stateDialogContent, setStateDialogContent] = useState<React.ReactNode>(null);
-    const scrollableContentRef = useRef<HTMLDivElement>(null);
     
-    // const onStateColumnClick = async (item: IDocument) => {
-    //     try {
-    //         //const text = await getTextForState(item);
-    //         // const text = item.status_updates[0].status;
-    //         const text = item.status_updates.map(update => update.status).join("\n");       
-    //         setStateDialogContent(text);
-    //         setStateDialogVisible(true);
-    //     } catch (error) {
-    //         console.error("Error on state column click:", error);
-    //         // Handle error here, perhaps show an error message to the user
-    //     }
-    // };
     const refreshProp = (item: any) => {
         setValue(item);
       };
@@ -409,22 +394,18 @@ export const DocumentsDetailList = ({ items, onFilesSorted}: Props) => {
 
     return (
         <div>
-            <span className={styles.footer}>{"(" + items.length as string + ") records."}</span>
-            <DetailsList
-                items={itemList}
-                compact={true}
-                columns={columns}
-                selection={selectionRef.current}
-                selectionMode={SelectionMode.multiple} // Allow multiple selection
-                getKey={getKey}
-                setKey="none"
-                layoutMode={DetailsListLayoutMode.justified}
-                isHeaderVisible={true}
-                onItemInvoked={onItemInvoked}
-            />
-            <span className={styles.footer}>{"(" + items.length as string + ") records."}</span>
-            <Button text="Delete" onClick={handleDeleteClick} style={{ marginRight: '10px' }} />
-            <Button text="Resubmit" onClick={handleResubmitClick} />
+            {/* <Button text="Delete" onClick={handleDeleteClick} style={{ marginRight: '10px' }} />
+            <Button text="Resubmit" onClick={handleResubmitClick} /> */}
+            <div className={styles.buttonsContainer}>
+                <div className={`${styles.refresharea} ${styles.divSpacing}`} onClick={handleDeleteClick} aria-label="Delete">
+                    <Delete24Regular className={styles.refreshicon} />
+                    <span className={`${styles.refreshtext} ${styles.centeredText}`}>Delete</span>
+                </div>
+                <div className={`${styles.refresharea} ${styles.divSpacing}`} onClick={handleResubmitClick} aria-label="Resubmit">
+                    <Send24Regular className={styles.refreshicon} />
+                    <span className={`${styles.refreshtext} ${styles.centeredText}`}>Resubmit</span>
+                </div>
+            </div>
             {/* Dialog for delete confirmation */}
             <Dialog
                 hidden={!isDeleteDialogVisible}
@@ -463,6 +444,20 @@ export const DocumentsDetailList = ({ items, onFilesSorted}: Props) => {
                     <DefaultButton onClick={() => setIsResubmitDialogVisible(false)} text="Cancel" />
                 </DialogFooter>
             </Dialog>
+            <span className={styles.footer}>{"(" + items.length as string + ") records."}</span>
+            <DetailsList
+                items={itemList}
+                compact={true}
+                columns={columns}
+                selection={selectionRef.current}
+                selectionMode={SelectionMode.multiple} // Allow multiple selection
+                getKey={getKey}
+                setKey="none"
+                layoutMode={DetailsListLayoutMode.justified}
+                isHeaderVisible={true}
+                onItemInvoked={onItemInvoked}
+            />
+            <span className={styles.footer}>{"(" + items.length as string + ") records."}</span>
             <div>
                 <Notification message={notification.message} />
             </div>

--- a/app/frontend/src/components/FileStatus/DocumentsDetailList.tsx
+++ b/app/frontend/src/components/FileStatus/DocumentsDetailList.tsx
@@ -3,7 +3,8 @@
 
 import React, { useState, useEffect, useRef, useLayoutEffect } from "react";
 import { Delete24Regular,
-    Send24Regular
+    Send24Regular,
+    ArrowClockwise24Filled
     } from "@fluentui/react-icons";
 
 import { DetailsList, 
@@ -50,9 +51,11 @@ export interface IDocument {
 interface Props {
     items: IDocument[];
     onFilesSorted?: (items: IDocument[]) => void;
+    onRefresh: () => void; // Add this line
 }
 
-export const DocumentsDetailList = ({ items, onFilesSorted}: Props) => {
+export const DocumentsDetailList = ({ items, onFilesSorted, onRefresh }: Props) => {
+
     const itemsRef = useRef(items);
 
     const onColumnClick = (ev: React.MouseEvent<HTMLElement>, column: IColumn): void => {
@@ -397,6 +400,10 @@ export const DocumentsDetailList = ({ items, onFilesSorted}: Props) => {
             {/* <Button text="Delete" onClick={handleDeleteClick} style={{ marginRight: '10px' }} />
             <Button text="Resubmit" onClick={handleResubmitClick} /> */}
             <div className={styles.buttonsContainer}>
+                <div className={`${styles.refresharea} ${styles.divSpacing}`} onClick={onRefresh} aria-label="Refresh">
+                    <ArrowClockwise24Filled className={styles.refreshicon} />
+                    <span className={`${styles.refreshtext} ${styles.centeredText}`}>Refresh</span>
+                </div>
                 <div className={`${styles.refresharea} ${styles.divSpacing}`} onClick={handleDeleteClick} aria-label="Delete">
                     <Delete24Regular className={styles.refreshicon} />
                     <span className={`${styles.refreshtext} ${styles.centeredText}`}>Delete</span>

--- a/app/frontend/src/components/FileStatus/FileStatus.tsx
+++ b/app/frontend/src/components/FileStatus/FileStatus.tsx
@@ -253,7 +253,7 @@ export const FileStatus = ({ className }: Props) => {
                 </animated.div>
             ) : (
                 <div className={styles.resultspanel}>
-                    <DocumentsDetailList items={files == undefined ? [] : files} onFilesSorted={onFilesSorted}/>
+                    <DocumentsDetailList items={files == undefined ? [] : files} onFilesSorted={onFilesSorted} onRefresh={onGetStatusClick}/>
                 </div>
             )}
         </div>

--- a/app/frontend/src/components/FileStatus/FileStatus.tsx
+++ b/app/frontend/src/components/FileStatus/FileStatus.tsx
@@ -235,10 +235,6 @@ export const FileStatus = ({ className }: Props) => {
                 styles={dropdownTagStyles}
                 aria-label="tag options for file statuses to be displayed"
             />
-            <div className={styles.refresharea} onClick={onGetStatusClick} aria-label="Refresh displayed file statuses">
-                <ArrowClockwise24Filled className={styles.refreshicon} />
-                <span className={styles.refreshtext}>Refresh</span>
-            </div>
             </div>
             {isLoading ? (
                 <animated.div style={{ ...animatedStyles }}>

--- a/app/frontend/src/components/FileStatus/FileStatus.tsx
+++ b/app/frontend/src/components/FileStatus/FileStatus.tsx
@@ -1,13 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { Dropdown, DropdownMenuItemType, IDropdownOption, IDropdownStyles } from '@fluentui/react/lib/Dropdown';
 import { Stack } from "@fluentui/react";
-import { DocumentsDetailList, IDocument } from "./DocumentsDetailList";
-import { ArrowClockwise24Filled } from "@fluentui/react-icons";
+import { DocumentsDetailList, IDocument, IDocumentsDetailList } from "./DocumentsDetailList";
 import { animated, useSpring } from "@react-spring/web";
 import { getAllUploadStatus, FileUploadBasicStatus, GetUploadStatusRequest, FileState, getFolders, getTags } from "../../api";
+import { Delete24Regular,
+    Send24Regular,
+    ArrowClockwise24Filled
+    } from "@fluentui/react-icons";
 
 import styles from "./FileStatus.module.css";
 
@@ -41,10 +44,12 @@ const dropdownFileStateOptions = [
     { key: FileState.DELETED, text: 'Deleted'},  
   ];
 
+const detailListRef = useRef<IDocumentsDetailList>(null);
 
 interface Props {
     className?: string;
 }
+
 
 export const FileStatus = ({ className }: Props) => {
     const [selectedTimeFrameItem, setSelectedTimeFrameItem] = useState<IDropdownOption>();
@@ -56,6 +61,19 @@ export const FileStatus = ({ className }: Props) => {
     const [tagOptions, setTagOptions] = useState<IDropdownOption[]>([]);
     const [files, setFiles] = useState<IDocument[]>();
     const [isLoading, setIsLoading] = useState<boolean>(false);
+
+    const detailListRef = useRef();
+
+    // Function to call handleDeleteClick from the child component
+    const onDeleteClick = () => {
+        detailListRef.current?.handleDeleteClick();
+    };
+
+    // Function to call handleResubmitClick from the child component
+    const onResubmitClick = () => {
+        detailListRef.current?.handleResubmitClick();
+        
+    };
 
     const onTimeSpanChange = (event: React.FormEvent<HTMLDivElement>, item: IDropdownOption<any> | undefined): void => {
         setSelectedTimeFrameItem(item);
@@ -236,6 +254,20 @@ export const FileStatus = ({ className }: Props) => {
                 aria-label="tag options for file statuses to be displayed"
             />
             </div>
+            <div className={styles.buttonsContainer}>
+                <div className={styles.refresharea} onClick={onGetStatusClick} aria-label="Refresh displayed file statuses">
+                    <ArrowClockwise24Filled className={styles.refreshicon} />
+                    <span className={styles.refreshtext}>Refresh</span>
+                </div>
+                <div className={`${styles.refresharea} ${styles.divSpacing}`} onClick={onDeleteClick} aria-label="Delete">
+                    <Delete24Regular className={styles.refreshicon} />
+                    <span className={`${styles.refreshtext} ${styles.centeredText}`}>Delete</span>
+                </div>
+                <div className={`${styles.refresharea} ${styles.divSpacing}`} onClick={onResubmitClick} aria-label="Resubmit">
+                    <Send24Regular className={styles.refreshicon} />
+                    <span className={`${styles.refreshtext} ${styles.centeredText}`}>Resubmit</span>
+                </div>
+            </div>
             {isLoading ? (
                 <animated.div style={{ ...animatedStyles }}>
                      <Stack className={styles.loadingContainer} verticalAlign="space-between">
@@ -249,7 +281,12 @@ export const FileStatus = ({ className }: Props) => {
                 </animated.div>
             ) : (
                 <div className={styles.resultspanel}>
-                    <DocumentsDetailList items={files == undefined ? [] : files} onFilesSorted={onFilesSorted} onRefresh={onGetStatusClick}/>
+                    <DocumentsDetailList 
+                        ref={detailListRef}
+                        items={files == undefined ? [] : files} 
+                        onFilesSorted={onFilesSorted} 
+                        onRefresh={onGetStatusClick}
+                    />
                 </div>
             )}
         </div>


### PR DESCRIPTION
This PR focuses on the upload status page. It covers the following points:

- delete and resubmit buttons are moved to the top of the table
- buttons have been changed to icons 
- the refresh button is now aligned with these under the selection boxes
- they have been formatted to look like buttons
- removed the hyperlink in cells to retry errors