### PR TITLE
change buttons to icons

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -25,7 +25,6 @@ from azure.storage.blob import (
     generate_account_sas,
 )
 from shared_code.status_log import State, StatusClassification, StatusLog, StatusQueryLevel
-from shared_code.tags_helper import TagsHelper
 from approaches.chatbingsearch import ChatBingSearch
 from azure.cosmos import CosmosClient
 
@@ -318,9 +317,9 @@ async def get_all_upload_status(request: Request):
         # retrieve tags for each file
          # Initialize an empty list to hold the tags
         items = []              
-        cosmos_client = CosmosClient(url=tagsHelper._url, credential=tagsHelper._key)
-        database = cosmos_client.get_database_client(tagsHelper._database_name)
-        container = database.get_container_client(tagsHelper._container_name)
+        cosmos_client = CosmosClient(url=statusLog._url, credential=statusLog._key)
+        database = cosmos_client.get_database_client(statusLog._database_name)
+        container = database.get_container_client(statusLog._container_name)
         query_string = "SELECT DISTINCT VALUE t FROM c JOIN t IN c.tags"
         items = list(container.query_items(
             query=query_string,

--- a/app/frontend/src/components/FileStatus/DocumentsDetailList.module.css
+++ b/app/frontend/src/components/FileStatus/DocumentsDetailList.module.css
@@ -70,3 +70,35 @@
   max-width: 400px;  /* Adjust the width as needed */
   overflow-y: auto;  /* This enables vertical scrolling */
 }
+
+.buttonsContainer {
+  display: flex;
+  align-items: center; /* Align items vertically in the center */
+  justify-content: flex-start; /* Align items to the start (left) of the container */
+}
+
+.refresharea {
+  display: flex;
+  align-items: center; /* Vertically center the text with the icon */
+  justify-content: center; /* Horizontally center the text and the icon */
+  background-color: transparent; /* Transparent background */
+  cursor: pointer; /* Change cursor to pointer on hover */
+  color: #606060; /* Mid-dark grey text */
+  padding-right: 20px; /* Add 10px padding on the right side */
+  padding-top: 10px; /* Add 20px padding on the top */
+}
+
+.divSpacing {
+  margin: 0px; /* Adjust as needed */
+}
+
+.centeredText {
+  text-align: left;
+}
+
+.refreshtext {
+  font-size: 0.8em; /* Smaller text size, adjust as needed */
+}
+
+.refreshicon {
+  fill: #606060; /* Mid-dark grey for SVG icons */}

--- a/app/frontend/src/components/FileStatus/DocumentsDetailList.tsx
+++ b/app/frontend/src/components/FileStatus/DocumentsDetailList.tsx
@@ -23,7 +23,7 @@ import { deleteItem, DeleteItemRequest, resubmitItem, ResubmitItemRequest } from
 import { StatusContent } from "../StatusContent/StatusContent";
 import { Delete24Regular,
     Send24Regular,
-    ArrowClockwise24Filled
+    ArrowClockwise24Regular
     } from "@fluentui/react-icons";
 
 export interface IDocument {

--- a/app/frontend/src/components/FileStatus/DocumentsDetailList.tsx
+++ b/app/frontend/src/components/FileStatus/DocumentsDetailList.tsx
@@ -398,7 +398,7 @@ export const DocumentsDetailList = ({ items, onFilesSorted, onRefresh }: Props) 
         <div>
             <div className={styles.buttonsContainer}>
                 <div className={`${styles.refresharea} ${styles.divSpacing}`} onClick={onRefresh} aria-label=" Refresh">
-                    <ArrowClockwise24Filled className={styles.refreshicon} />
+                    <ArrowClockwise24Regular className={styles.refreshicon} />
                     <span className={`${styles.refreshtext} ${styles.centeredText}`}>Refresh</span>
                 </div>        
                 <div className={`${styles.refresharea} ${styles.divSpacing}`} onClick={handleDeleteClick} aria-label=" Delete">

--- a/app/frontend/src/components/FileStatus/DocumentsDetailList.tsx
+++ b/app/frontend/src/components/FileStatus/DocumentsDetailList.tsx
@@ -331,13 +331,11 @@ export const DocumentsDetailList = ({ items, onFilesSorted, onRefresh }: Props) 
             fieldName: 'tags',
             minWidth: 70,
             maxWidth: 90,
-            isRowHeader: true,
             isResizable: true,
             sortAscendingAriaLabel: 'Sorted A to Z',
             sortDescendingAriaLabel: 'Sorted Z to A',
             onColumnClick: onColumnClick,
             data: 'string',
-
             isPadded: true,
         },
         {

--- a/app/frontend/src/components/FileStatus/DocumentsDetailList.tsx
+++ b/app/frontend/src/components/FileStatus/DocumentsDetailList.tsx
@@ -17,14 +17,14 @@ import { DetailsList,
     DefaultButton, 
     Panel,
     PanelType} from "@fluentui/react";
- import { Resizable, ResizableBox } from "react-resizable";
 import { retryFile } from "../../api";
 import styles from "./DocumentsDetailList.module.css";
 import { deleteItem, DeleteItemRequest, resubmitItem, ResubmitItemRequest } from "../../api";
 import { StatusContent } from "../StatusContent/StatusContent";
-import Draggable from "react-draggable";
-// import Resizable from "re-resizable";
-// import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
+import { Delete24Regular,
+    Send24Regular,
+    ArrowClockwise24Filled
+    } from "@fluentui/react-icons";
 
 export interface IDocument {
     key: string;
@@ -50,9 +50,10 @@ export interface IDocument {
 interface Props {
     items: IDocument[];
     onFilesSorted?: (items: IDocument[]) => void;
+    onRefresh: () => void; 
 }
 
-export const DocumentsDetailList = ({ items, onFilesSorted}: Props) => {
+export const DocumentsDetailList = ({ items, onFilesSorted, onRefresh }: Props) => {
     const itemsRef = useRef(items);
 
     const onColumnClick = (ev: React.MouseEvent<HTMLElement>, column: IColumn): void => {
@@ -224,19 +225,7 @@ export const DocumentsDetailList = ({ items, onFilesSorted}: Props) => {
     const [stateDialogVisible, setStateDialogVisible] = useState(false);
     const [stateDialogContent, setStateDialogContent] = useState<React.ReactNode>(null);
     const scrollableContentRef = useRef<HTMLDivElement>(null);
-    
-    // const onStateColumnClick = async (item: IDocument) => {
-    //     try {
-    //         //const text = await getTextForState(item);
-    //         // const text = item.status_updates[0].status;
-    //         const text = item.status_updates.map(update => update.status).join("\n");       
-    //         setStateDialogContent(text);
-    //         setStateDialogVisible(true);
-    //     } catch (error) {
-    //         console.error("Error on state column click:", error);
-    //         // Handle error here, perhaps show an error message to the user
-    //     }
-    // };
+
     const refreshProp = (item: any) => {
         setValue(item);
       };
@@ -310,9 +299,9 @@ export const DocumentsDetailList = ({ items, onFilesSorted}: Props) => {
             onColumnClick: onColumnClick,
             data: 'string',
             onRender: (item: IDocument) => (
-                <TooltipHost content={`${item.state} `}>
-                    <span onClick={() => onStateColumnClick(item)} style={{ cursor: 'pointer', color:'blue', textDecoration:'underline' }}>
-                        {item.state}
+                <TooltipHost content={`${item.state_description} `}>
+                    <span onClick={() => onStateColumnClick(item)} style={{ cursor: 'pointer' }}>
+                        {item.state_description}
                     </span>
                     {item.state === 'Error' && <a href="javascript:void(0);" onClick={() => retryErroredFile(item)}> - Retry File</a>}
                 </TooltipHost>
@@ -409,6 +398,20 @@ export const DocumentsDetailList = ({ items, onFilesSorted}: Props) => {
 
     return (
         <div>
+            <div className={styles.buttonsContainer}>
+                <div className={`${styles.refresharea} ${styles.divSpacing}`} onClick={onRefresh} aria-label=" Refresh">
+                    <ArrowClockwise24Filled className={styles.refreshicon} />
+                    <span className={`${styles.refreshtext} ${styles.centeredText}`}>Refresh</span>
+                </div>        
+                <div className={`${styles.refresharea} ${styles.divSpacing}`} onClick={handleDeleteClick} aria-label=" Delete">
+                    <Delete24Regular className={styles.refreshicon} />
+                    <span className={`${styles.refreshtext} ${styles.centeredText}`}>Delete</span>
+                </div>
+                <div className={`${styles.refresharea} ${styles.divSpacing}`} onClick={handleResubmitClick} aria-label=" Resubmit">
+                    <Send24Regular className={styles.refreshicon} />
+                    <span className={`${styles.refreshtext} ${styles.centeredText}`}>Resubmit</span>
+                </div>
+            </div>
             <span className={styles.footer}>{"(" + items.length as string + ") records."}</span>
             <DetailsList
                 items={itemList}
@@ -423,8 +426,8 @@ export const DocumentsDetailList = ({ items, onFilesSorted}: Props) => {
                 onItemInvoked={onItemInvoked}
             />
             <span className={styles.footer}>{"(" + items.length as string + ") records."}</span>
-            <Button text="Delete" onClick={handleDeleteClick} style={{ marginRight: '10px' }} />
-            <Button text="Resubmit" onClick={handleResubmitClick} />
+            {/* <Button text="Delete" onClick={handleDeleteClick} style={{ marginRight: '10px' }} />
+            <Button text="Resubmit" onClick={handleResubmitClick} /> */}
             {/* Dialog for delete confirmation */}
             <Dialog
                 hidden={!isDeleteDialogVisible}
@@ -465,8 +468,7 @@ export const DocumentsDetailList = ({ items, onFilesSorted}: Props) => {
             </Dialog>
             <div>
                 <Notification message={notification.message} />
-            </div>
-            
+            </div>            
                 <Panel
                     headerText="Status Log"
                     isOpen={stateDialogVisible}
@@ -481,26 +483,6 @@ export const DocumentsDetailList = ({ items, onFilesSorted}: Props) => {
                     <StatusContent item={value} />
                     </div>
                 </Panel>
-                
-            {/* <Dialog
-                hidden={!stateDialogVisible}
-                onDismiss={() => setStateDialogVisible(false)}
-                dialogContentProps={{
-                    type: DialogType.normal,
-                    title: 'State Details',
-                    closeButtonAriaLabel: 'Close',
-                }}
-                modalProps={{
-                    styles: dialogStyles,
-                }}
-            >
-                <div className="scrollableDialogContent" ref={scrollableContentRef}>
-                    {stateDialogContent}
-                </div>
-                <DialogFooter>
-                    <PrimaryButton onClick={() => setStateDialogVisible(false)} text="OK" />
-                </DialogFooter>
-            </Dialog> */}
         </div>
     );
 }

--- a/app/frontend/src/components/FileStatus/FileStatus.tsx
+++ b/app/frontend/src/components/FileStatus/FileStatus.tsx
@@ -199,46 +199,42 @@ export const FileStatus = ({ className }: Props) => {
     return (
         <div className={styles.container}>
             <div className={`${styles.options} ${className ?? ""}`} >
-            <Dropdown
-                    label="Uploaded in last:"
-                    defaultSelectedKey='4hours'
-                    onChange={onTimeSpanChange}
-                    placeholder="Select a time range"
-                    options={dropdownTimespanOptions}
-                    styles={dropdownTimespanStyles}
-                    aria-label="timespan options for file statuses to be displayed"
+                <Dropdown
+                        label="Uploaded in last:"
+                        defaultSelectedKey='4hours'
+                        onChange={onTimeSpanChange}
+                        placeholder="Select a time range"
+                        options={dropdownTimespanOptions}
+                        styles={dropdownTimespanStyles}
+                        aria-label="timespan options for file statuses to be displayed"
+                    />
+                <Dropdown
+                        label="File State:"
+                        defaultSelectedKey={'ALL'}
+                        onChange={onFileStateChange}
+                        placeholder="Select file states"
+                        options={dropdownFileStateOptions}
+                        styles={dropdownFileStateStyles}
+                        aria-label="file state options for file statuses to be displayed"
+                    />
+                <Dropdown
+                    label="Folder:"
+                    defaultSelectedKey={'Root'}
+                    onChange={onFolderChange}
+                    placeholder="Select folder"
+                    options={folderOptions}
+                    styles={dropdownFolderStyles}
+                    aria-label="folder options for file statuses to be displayed"
                 />
-            <Dropdown
-                    label="File State:"
-                    defaultSelectedKey={'ALL'}
-                    onChange={onFileStateChange}
-                    placeholder="Select file states"
-                    options={dropdownFileStateOptions}
-                    styles={dropdownFileStateStyles}
-                    aria-label="file state options for file statuses to be displayed"
+                <Dropdown
+                    label="Tag:"
+                    defaultSelectedKey={'All'}
+                    onChange={onTagChange}
+                    placeholder="Select a tag"
+                    options={tagOptions}
+                    styles={dropdownTagStyles}
+                    aria-label="tag options for file statuses to be displayed"
                 />
-            <Dropdown
-                label="Folder:"
-                defaultSelectedKey={'Root'}
-                onChange={onFolderChange}
-                placeholder="Select folder"
-                options={folderOptions}
-                styles={dropdownFolderStyles}
-                aria-label="folder options for file statuses to be displayed"
-            />
-            <Dropdown
-                label="Tag:"
-                defaultSelectedKey={'All'}
-                onChange={onTagChange}
-                placeholder="Select a tag"
-                options={tagOptions}
-                styles={dropdownTagStyles}
-                aria-label="tag options for file statuses to be displayed"
-            />
-            <div className={styles.refresharea} onClick={onGetStatusClick} aria-label="Refresh displayed file statuses">
-                <ArrowClockwise24Filled className={styles.refreshicon} />
-                <span className={styles.refreshtext}>Refresh</span>
-            </div>
             </div>
             {isLoading ? (
                 <animated.div style={{ ...animatedStyles }}>
@@ -253,7 +249,7 @@ export const FileStatus = ({ className }: Props) => {
                 </animated.div>
             ) : (
                 <div className={styles.resultspanel}>
-                    <DocumentsDetailList items={files == undefined ? [] : files} onFilesSorted={onFilesSorted}/>
+                    <DocumentsDetailList items={files == undefined ? [] : files} onFilesSorted={onFilesSorted} onRefresh={onGetStatusClick}/>
                 </div>
             )}
         </div>

--- a/functions/FileDeletion/__init__.py
+++ b/functions/FileDeletion/__init__.py
@@ -121,7 +121,7 @@ def main(mytimer: func.TimerRequest) -> None:
             deleted_content_blobs = delete_content_blobs(blob_service_client, blob)
             logging.info("%s content blobs deleted.", str(len(deleted_content_blobs)))
             delete_search_entries(deleted_content_blobs)
-            tags_helper.delete_doc(blob)
+            status_log.delete_doc(blob)
 
             # for doc in deleted_blobs:
             doc_base = os.path.basename(blob)


### PR DESCRIPTION
This PR focuses on the upload status page. It covers the following points:

- delete and resubmit buttons are moved to the top of the table
- buttons have been changed to icons
- the refresh button is now aligned with these under the selection boxes
- removed the hyperlink in cells to retry errors
- fixed font on tags column