### PR TITLE
Put in Feature flags to local.env, in TF deployment, and pass to web app

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -170,9 +170,13 @@ module "backend" {
     APPLICATION_TITLE                       = var.applicationtitle
     AZURE_AI_TRANSLATION_DOMAIN             = var.azure_ai_translation_domain
     USE_SEMANTIC_RERANKER                   = var.use_semantic_reranker
-    BING_SEARCH_ENDPOINT                    = var.azure_environment == "AzureCloud" ? module.bingSearch[0].endpoint : ""
-    BING_SEARCH_KEY                         = var.azure_environment == "AzureCloud" ? module.bingSearch[0].key : ""
+    BING_SEARCH_ENDPOINT                    = var.enableWebChat ? module.bingSearch[0].endpoint : ""
+    BING_SEARCH_KEY                         = var.enableWebChat ? module.bingSearch[0].key : ""
+    ENABLE_WEB_CHAT                         = var.enableWebChat
     ENABLE_BING_SAFE_SEARCH                 = var.enableBingSafeSearch
+    ENABLE_UNGROUNDED_CHAT                  = var.enableUngroundedChat
+    ENABLE_MATH_TUTOR                       = var.enableMathTutor
+    ENABLE_CSV_AGENT                        = var.enableCsvAgent
   }
 
   aadClientId = module.entraObjects.azure_ad_web_app_client_id
@@ -259,7 +263,7 @@ module "cosmosdb" {
   logDatabaseName   = "statusdb"
   logContainerName  = "statuscontainer"
   resourceGroupName = azurerm_resource_group.rg.name
-  keyVaultId        = module.kvModule.keyVaultId 
+  keyVaultId        = module.kvModule.keyVaultId  
 }
 
 
@@ -334,6 +338,7 @@ module "functions" {
 }
 
 module "sharepoint" {
+  count                               = var.enableSharePointConnector ? 1 : 0
   source                              = "./core/sharepoint"
   location                            = azurerm_resource_group.rg.location
   resource_group_name                 = azurerm_resource_group.rg.name
@@ -471,7 +476,7 @@ module "kvModule" {
 }
 
 module "bingSearch" {
-  count                         = var.azure_environment == "AzureCloud" ? 1 : 0
+  count                         = var.enableWebChat ? 1 : 0
   source                        = "./core/ai/bingSearch"
   name                          = "infoasst-bing-${random_string.random.result}"
   resourceGroupName             = azurerm_resource_group.rg.name

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -164,11 +164,11 @@ output "AZURE_ENVIRONMENT" {
 }
 
 output "BING_SEARCH_ENDPOINT" {
-  value = var.azure_environment == "AzureCloud" ? module.bingSearch[0].endpoint : ""
+  value = var.enableWebChat ? module.bingSearch[0].endpoint : ""
 }
 
 output "BING_SEARCH_KEY" {
-  value = var.azure_environment == "AzureCloud" ? module.bingSearch[0].key : ""
+  value = var.enableWebChat ? module.bingSearch[0].key : ""
 }
 
 output "ENABLE_BING_SAFE_SEARCH" {

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -48,6 +48,31 @@ variable "enableBingSafeSearch" {
   default = true
 }
 
+variable "enableWebChat" {
+  type    = bool
+  default = true
+}
+
+variable "enableUngroundedChat" {
+  type    = bool
+  default = false
+}
+
+variable "enableMathTutor" {
+  type    = bool
+  default = true
+}
+
+variable "enableCsvAgent" {
+  type    = bool
+  default = true
+}
+
+variable "enableSharePointConnector" {
+  type    = bool
+  default = false
+}
+
 ////
 // variables that can vary based on the Azure environment being targeted
 ////

--- a/scripts/environments/local.env.example
+++ b/scripts/environments/local.env.example
@@ -8,9 +8,44 @@ export WORKSPACE="myworkspace" # Required
 export SUBSCRIPTION_ID="" # Required
 export TENANT_ID="" # Required
 
-#Update to target other environments such as AzureUSGovernment. 
-#More details at https://docs.microsoft.com/en-us/cli/azure/manage-clouds-azure-cli?toc=/cli/azure/toc.json&bc=/cli/azure/breadcrumb/toc.json
+# ----------------------------------------------------------
+# The following values determine the features that are enabled in the deployment.
+# All of the feature flag parameters are required except for the SHAREPOINT_SITES and SHAREPOINT_FOLDERS parameters.
+# ----------------------------------------------------------
+#Update to target different environments. Supported values are AzureCloud, AzureUSGovernment. 
 export AZURE_ENVIRONMENT="AzureCloud"
+# Update to "true" if you want to deploy the solution in a "secure" mode. The secure mode requires extra permissions and will require
+# the user to have special access. In the "secure" mode, traffic within the Information Assistant will not use public endpoints.
+export SECURE_MODE=false
+# Update to "true" if you want to deploy the solution with the ability to use the Work + Web Chat feature.
+# This feature will allow users to use web based search results to be a data source for grounding in the chat.
+# Web Chat feature IS NOT supported in AZURE_ENVIRONMENT="AzureUSGovernment"
+export ENABLE_WEB_CHAT=true
+# If you are enabling the Web Chat feature, you can update the following values to "true" to enable safe search for the Bing data source.
+# Defaults to true if not defined.
+export ENABLE_BING_SAFE_SEARCH=true
+# Update to "true" if you want to deploy the solution with the ability to use the Generative Chat feature.
+# This feature will allow users to use native responses from the LLM without any data source for grounding in the chat.
+export ENABLE_UNGROUNDED_CHAT=false
+# Update to "true" if you want to deploy the solution with the ability to use the Math Tutor feature.
+# This feature will allow users to use the Math Tutor feature to solve math problems.
+export ENABLE_MATH_TUTOR=true
+# Update to "true" if you want to deploy the solution with the ability to use the CSV Agent feature.
+# This feature will allow users to use the CSV Agent feature to query CSV files.
+export ENABLE_CSV_AGENT=true
+# Update to "true" if you want to deploy the solution with the ability to ingest data from SharePoint sites.
+# This feature will allow users to use the SharePoint connector to ingest documents from folders in SharePoint.
+export ENABLE_SHAREPOINT_CONNECTOR=false
+# If the SharePoint connector is enabled, use the following settings for a list of sharepoint sites and folders you want to index. 
+# If SHAREPOINT_SITES is set to "example.sharepoint.com, example2.sharepoint.com" and
+# SHAREPOINT_FOLDERS is set to "folder1, folder2" then the sharepoint connector will index
+# folder1 from example.sharepoint.com and folder2 from example2.sharepoint.com
+# The position of the folder in the list should match the position of the site in the list.
+export SHAREPOINT_SITES="" # This should be a comma separated list of sharepoint site urls 
+export SHAREPOINT_FOLDERS="" # This should be a comma separated list of sharepoint folders
+# ----------------------------------------------------------
+# End of feature flags
+# ----------------------------------------------------------
 
 # Use this setting to determine whether a user needs to be granted explicit access to the website via an
 # Azure AD Enterprise Application membership (true) or allow the website to be available to anyone in the Azure tenant (false). Defaults to false.
@@ -21,6 +56,8 @@ export REQUIRE_WEBSITE_SECURITY_MEMBERSHIP=false # Required
 # export SKIP_PLAN_CHECK=1
 
 # If using an existing deployment of Azure OpenAI, set the USE_EXISTING_AOAI to true and fill in the following values
+# If you are deploying a new instance of Azure OpenAI, set the USE_EXISTING_AOAI to false and the following values are not required
+# Using and existing instance of Azure OpenAI will NOT be allowed if deploying in Secure Mode
 export USE_EXISTING_AOAI=false # Required
 export AZURE_OPENAI_RESOURCE_GROUP=""
 export AZURE_OPENAI_SERVICE_NAME=""
@@ -88,27 +125,12 @@ export DEFAULT_LANGUAGE="en-US" # Required
 export ENABLE_CUSTOMER_USAGE_ATTRIBUTION=true
 export CUSTOMER_USAGE_ATTRIBUTION_ID="7a01ff74-15c2-4fec-9f14-63db7d3d6131"
 
-# If you are using the Bing Search API, you can set the following values to enable safe search.
-# Defaults to true if not defined.
-export ENABLE_BING_SAFE_SEARCH=true
-
 # Branding
 # Leave application title blank for the default name
 export APPLICATION_TITLE=""
 
 # Video Indexer API Version used in ARM deployment of Azure Video Indexer
 export VIDEO_INDEXER_API_VERSION="2024-01-01"
-
-# The list of sharepoint sites and folders you want to index. 
-# If SHAREPOINT_SITES is set to "example.sharepoint.com, example2.sharepoint.com" and
-# SHAREPOINT_FOLDERS is set to "folder1, folder2" then the sharepoint connector will index
-# folder1 from example.sharepoint.com and folder2 from example2.sharepoint.com
-# The position of the folder in the list should match the position of the site in the list.
-
-# This should be a comma separated list of sharepoint site urls 
-export SHAREPOINT_SITES=""
-# This should be a comma separated list of sharepoint folders
-export SHAREPOINT_FOLDERS=""
 
 # Enable capabilities under development. This should be set to false
 export ENABLE_DEV_CODE=false

--- a/scripts/environments/shared-ia-dev.env
+++ b/scripts/environments/shared-ia-dev.env
@@ -4,7 +4,44 @@ export LOCATION="eastus"
 export WORKSPACE="shared-vnext"
 export SUBSCRIPTION_ID="$ARM_SUBSCRIPTION_ID"
 
+# ----------------------------------------------------------
+# The following values determine the features that are enabled in the deployment.
+# All of the feature flag parameters are required except for the SHAREPOINT_SITES and SHAREPOINT_FOLDERS parameters.
+# ----------------------------------------------------------
+#Update to target different environments. Supported values are AzureCloud, AzureUSGovernment. 
 export AZURE_ENVIRONMENT="AzureCloud"
+# Update to "true" if you want to deploy the solution in a "secure" mode. The secure mode requires extra permissions and will require
+# the user to have special access. In the "secure" mode, traffic within the Information Assistant will not use public endpoints.
+export SECURE_MODE=false
+# Update to "true" if you want to deploy the solution with the ability to use the Work + Web Chat feature.
+# This feature will allow users to use web based search results to be a data source for grounding in the chat.
+# Web Chat feature IS NOT supported in AZURE_ENVIRONMENT="AzureUSGovernment"
+export ENABLE_WEB_CHAT=true
+# If you are enabling the Web Chat feature, you can update the following values to "true" to enable safe search for the Bing data source.
+# Defaults to true if not defined.
+export ENABLE_BING_SAFE_SEARCH=true
+# Update to "true" if you want to deploy the solution with the ability to use the Generative Chat feature.
+# This feature will allow users to use native responses from the LLM without any data source for grounding in the chat.
+export ENABLE_UNGROUNDED_CHAT=false
+# Update to "true" if you want to deploy the solution with the ability to use the Math Tutor feature.
+# This feature will allow users to use the Math Tutor feature to solve math problems.
+export ENABLE_MATH_TUTOR=true
+# Update to "true" if you want to deploy the solution with the ability to use the CSV Agent feature.
+# This feature will allow users to use the CSV Agent feature to query CSV files.
+export ENABLE_CSV_AGENT=true
+# Update to "true" if you want to deploy the solution with the ability to ingest data from SharePoint sites.
+# This feature will allow users to use the SharePoint connector to ingest documents from folders in SharePoint.
+export ENABLE_SHAREPOINT_CONNECTOR=true
+# If the SharePoint connector is enabled, use the following settings for a list of sharepoint sites and folders you want to index. 
+# If SHAREPOINT_SITES is set to "example.sharepoint.com, example2.sharepoint.com" and
+# SHAREPOINT_FOLDERS is set to "folder1, folder2" then the sharepoint connector will index
+# folder1 from example.sharepoint.com and folder2 from example2.sharepoint.com
+# The position of the folder in the list should match the position of the site in the list.
+export SHAREPOINT_SITES="" # This should be a comma separated list of sharepoint site urls 
+export SHAREPOINT_FOLDERS="" # This should be a comma separated list of sharepoint folders
+# ----------------------------------------------------------
+# End of feature flags
+# ----------------------------------------------------------
 
 # Use this setting to determine whether a user needs to be granted explicit access to the website via an 
 # Azure AD Enterprise Application membership (true) or allow the website to be available to anyone in the Azure tenant (false). Defaults to false. 

--- a/scripts/environments/shared-ia.env
+++ b/scripts/environments/shared-ia.env
@@ -4,7 +4,44 @@ export LOCATION="eastus"
 export WORKSPACE="shared"
 export SUBSCRIPTION_ID="$ARM_SUBSCRIPTION_ID"
 
+# ----------------------------------------------------------
+# The following values determine the features that are enabled in the deployment.
+# All of the feature flag parameters are required except for the SHAREPOINT_SITES and SHAREPOINT_FOLDERS parameters.
+# ----------------------------------------------------------
+#Update to target different environments. Supported values are AzureCloud, AzureUSGovernment. 
 export AZURE_ENVIRONMENT="AzureCloud"
+# Update to "true" if you want to deploy the solution in a "secure" mode. The secure mode requires extra permissions and will require
+# the user to have special access. In the "secure" mode, traffic within the Information Assistant will not use public endpoints.
+export SECURE_MODE=false
+# Update to "true" if you want to deploy the solution with the ability to use the Work + Web Chat feature.
+# This feature will allow users to use web based search results to be a data source for grounding in the chat.
+# Web Chat feature IS NOT supported in AZURE_ENVIRONMENT="AzureUSGovernment"
+export ENABLE_WEB_CHAT=true
+# If you are enabling the Web Chat feature, you can update the following values to "true" to enable safe search for the Bing data source.
+# Defaults to true if not defined.
+export ENABLE_BING_SAFE_SEARCH=true
+# Update to "true" if you want to deploy the solution with the ability to use the Generative Chat feature.
+# This feature will allow users to use native responses from the LLM without any data source for grounding in the chat.
+export ENABLE_UNGROUNDED_CHAT=false
+# Update to "true" if you want to deploy the solution with the ability to use the Math Tutor feature.
+# This feature will allow users to use the Math Tutor feature to solve math problems.
+export ENABLE_MATH_TUTOR=true
+# Update to "true" if you want to deploy the solution with the ability to use the CSV Agent feature.
+# This feature will allow users to use the CSV Agent feature to query CSV files.
+export ENABLE_CSV_AGENT=true
+# Update to "true" if you want to deploy the solution with the ability to ingest data from SharePoint sites.
+# This feature will allow users to use the SharePoint connector to ingest documents from folders in SharePoint.
+export ENABLE_SHAREPOINT_CONNECTOR=true
+# If the SharePoint connector is enabled, use the following settings for a list of sharepoint sites and folders you want to index. 
+# If SHAREPOINT_SITES is set to "example.sharepoint.com, example2.sharepoint.com" and
+# SHAREPOINT_FOLDERS is set to "folder1, folder2" then the sharepoint connector will index
+# folder1 from example.sharepoint.com and folder2 from example2.sharepoint.com
+# The position of the folder in the list should match the position of the site in the list.
+export SHAREPOINT_SITES="" # This should be a comma separated list of sharepoint site urls 
+export SHAREPOINT_FOLDERS="" # This should be a comma separated list of sharepoint folders
+# ----------------------------------------------------------
+# End of feature flags
+# ----------------------------------------------------------
 
 # Use this setting to determine whether a user needs to be granted explicit access to the website via an 
 # Azure AD Enterprise Application membership (true) or allow the website to be available to anyone in the Azure tenant (false). Defaults to false. 

--- a/scripts/environments/tmp-ia.env
+++ b/scripts/environments/tmp-ia.env
@@ -4,7 +4,44 @@ export LOCATION="eastus"
 export WORKSPACE="tmp$BUILD_BUILDID"
 export SUBSCRIPTION_ID="$ARM_SUBSCRIPTION_ID"
 
+# ----------------------------------------------------------
+# The following values determine the features that are enabled in the deployment.
+# All of the feature flag parameters are required except for the SHAREPOINT_SITES and SHAREPOINT_FOLDERS parameters.
+# ----------------------------------------------------------
+#Update to target different environments. Supported values are AzureCloud, AzureUSGovernment. 
 export AZURE_ENVIRONMENT="AzureCloud"
+# Update to "true" if you want to deploy the solution in a "secure" mode. The secure mode requires extra permissions and will require
+# the user to have special access. In the "secure" mode, traffic within the Information Assistant will not use public endpoints.
+export SECURE_MODE=false
+# Update to "true" if you want to deploy the solution with the ability to use the Work + Web Chat feature.
+# This feature will allow users to use web based search results to be a data source for grounding in the chat.
+# Web Chat feature IS NOT supported in AZURE_ENVIRONMENT="AzureUSGovernment"
+export ENABLE_WEB_CHAT=true
+# If you are enabling the Web Chat feature, you can update the following values to "true" to enable safe search for the Bing data source.
+# Defaults to true if not defined.
+export ENABLE_BING_SAFE_SEARCH=true
+# Update to "true" if you want to deploy the solution with the ability to use the Generative Chat feature.
+# This feature will allow users to use native responses from the LLM without any data source for grounding in the chat.
+export ENABLE_UNGROUNDED_CHAT=false
+# Update to "true" if you want to deploy the solution with the ability to use the Math Tutor feature.
+# This feature will allow users to use the Math Tutor feature to solve math problems.
+export ENABLE_MATH_TUTOR=true
+# Update to "true" if you want to deploy the solution with the ability to use the CSV Agent feature.
+# This feature will allow users to use the CSV Agent feature to query CSV files.
+export ENABLE_CSV_AGENT=true
+# Update to "true" if you want to deploy the solution with the ability to ingest data from SharePoint sites.
+# This feature will allow users to use the SharePoint connector to ingest documents from folders in SharePoint.
+export ENABLE_SHAREPOINT_CONNECTOR=true
+# If the SharePoint connector is enabled, use the following settings for a list of sharepoint sites and folders you want to index. 
+# If SHAREPOINT_SITES is set to "example.sharepoint.com, example2.sharepoint.com" and
+# SHAREPOINT_FOLDERS is set to "folder1, folder2" then the sharepoint connector will index
+# folder1 from example.sharepoint.com and folder2 from example2.sharepoint.com
+# The position of the folder in the list should match the position of the site in the list.
+export SHAREPOINT_SITES="" # This should be a comma separated list of sharepoint site urls 
+export SHAREPOINT_FOLDERS="" # This should be a comma separated list of sharepoint folders
+# ----------------------------------------------------------
+# End of feature flags
+# ----------------------------------------------------------
 
 # Use this setting to determine whether a user needs to be granted explicit access to the website via an 
 # Azure AD Enterprise Application membership (true) or allow the website to be available to anyone in the Azure tenant (false). Defaults to false. 
@@ -42,7 +79,3 @@ export ENABLE_DEV_CODE=false
 
 # Video Indexer API Version used in ARM deployment of Azure Video Indexer
 export VIDEO_INDEXER_API_VERSION="2024-01-01"
-
-# If you are using the Bing Search API, you can set the following values to enable safe search.
-# Defaults to true if not defined.
-export ENABLE_BING_SAFE_SEARCH=true

--- a/scripts/environments/usgov-ia.env
+++ b/scripts/environments/usgov-ia.env
@@ -4,7 +4,44 @@ export LOCATION="usgovvirginia"
 export WORKSPACE="tmp_gov$BUILD_BUILDID"
 export SUBSCRIPTION_ID="$ARM_SUBSCRIPTION_ID"
 
+# ----------------------------------------------------------
+# The following values determine the features that are enabled in the deployment.
+# All of the feature flag parameters are required except for the SHAREPOINT_SITES and SHAREPOINT_FOLDERS parameters.
+# ----------------------------------------------------------
+#Update to target different environments. Supported values are AzureCloud, AzureUSGovernment. 
 export AZURE_ENVIRONMENT="AzureUSGovernment"
+# Update to "true" if you want to deploy the solution in a "secure" mode. The secure mode requires extra permissions and will require
+# the user to have special access. In the "secure" mode, traffic within the Information Assistant will not use public endpoints.
+export SECURE_MODE=false
+# Update to "true" if you want to deploy the solution with the ability to use the Work + Web Chat feature.
+# This feature will allow users to use web based search results to be a data source for grounding in the chat.
+# Web Chat feature IS NOT supported in AZURE_ENVIRONMENT="AzureUSGovernment"
+export ENABLE_WEB_CHAT=false
+# If you are enabling the Web Chat feature, you can update the following values to "true" to enable safe search for the Bing data source.
+# Defaults to true if not defined.
+export ENABLE_BING_SAFE_SEARCH=true
+# Update to "true" if you want to deploy the solution with the ability to use the Generative Chat feature.
+# This feature will allow users to use native responses from the LLM without any data source for grounding in the chat.
+export ENABLE_UNGROUNDED_CHAT=false
+# Update to "true" if you want to deploy the solution with the ability to use the Math Tutor feature.
+# This feature will allow users to use the Math Tutor feature to solve math problems.
+export ENABLE_MATH_TUTOR=true
+# Update to "true" if you want to deploy the solution with the ability to use the CSV Agent feature.
+# This feature will allow users to use the CSV Agent feature to query CSV files.
+export ENABLE_CSV_AGENT=true
+# Update to "true" if you want to deploy the solution with the ability to ingest data from SharePoint sites.
+# This feature will allow users to use the SharePoint connector to ingest documents from folders in SharePoint.
+export ENABLE_SHAREPOINT_CONNECTOR=true
+# If the SharePoint connector is enabled, use the following settings for a list of sharepoint sites and folders you want to index. 
+# If SHAREPOINT_SITES is set to "example.sharepoint.com, example2.sharepoint.com" and
+# SHAREPOINT_FOLDERS is set to "folder1, folder2" then the sharepoint connector will index
+# folder1 from example.sharepoint.com and folder2 from example2.sharepoint.com
+# The position of the folder in the list should match the position of the site in the list.
+export SHAREPOINT_SITES="" # This should be a comma separated list of sharepoint site urls 
+export SHAREPOINT_FOLDERS="" # This should be a comma separated list of sharepoint folders
+# ----------------------------------------------------------
+# End of feature flags
+# ----------------------------------------------------------
 
 # Use this setting to determine whether a user needs to be granted explicit access to the website via an 
 # Azure AD Enterprise Application membership (true) or allow the website to be available to anyone in the Azure tenant (false). Defaults to false. 

--- a/scripts/load-env.sh
+++ b/scripts/load-env.sh
@@ -58,16 +58,30 @@ if [ -f "$ENV_DIR/environments/AzureEnvironments/$AZURE_ENVIRONMENT.env" ]; then
     echo "Loading environment variables for Azure Environment: $AZURE_ENVIRONMENT."
     source "$ENV_DIR/environments/AzureEnvironments/$AZURE_ENVIRONMENT.env"
 else
-    echo "No Azure Environment set, please check local.env.example for AZURE_ENVIRONMENT"
+    echo -e "\n"
+    echo "\e[31mNo Azure Environment set, please check local.env.example for AZURE_ENVIRONMENT\e[0m\n"
+    exit 1
+fi
+
+# Fail if the following feature flag combinations are set
+if [[ $ENABLE_WEB_CHAT == true ]] && [[ $AZURE_ENVIRONMENT == "AzureUSGovernment" ]]; then
+    echo -e "\n"
+    echo -e "\e[31mWeb Chat is not available on AzureUSGovernment deployments. Check your values for ENABLE_WEB_CHAT and AZURE_ENVIRONMENT.\e[0m\n"
+    exit 1
+fi
+
+if [[ $SECURE_MODE == true && $USE_EXISTING_AOAI == true ]]; then
+    echo -e "\n"
+    echo -e "\e[31mSecure Mode and Use Existing AOAI cannot be enabled at the same time. We do not want to alter the security of an existing AOAI instance to avoid disruption of other services dependent on the shared instance. Check your values for SECURE_MODE and USE_EXISTING_AOAI.\e[0m\n"
     exit 1
 fi
 
 # Fail if the following environment variables are not set
 if [[ -z $WORKSPACE ]]; then
-    echo "WORKSPACE must be set."
+    echo "\e[31mWORKSPACE must be set.\e[0m\n"
     exit 1
 elif [[ "${WORKSPACE}" =~ [[:upper:]] ]]; then
-    echo "Please use a lowercase workspace environment variable between 1-15 characters. Please check 'private.env.example'"
+    echo "\e[33mPlease use a lowercase workspace environment variable between 1-15 characters. Please check 'local.env.example'\e[0m\n"
     exit 1
 fi
 

--- a/scripts/prepare-tf-variables.sh
+++ b/scripts/prepare-tf-variables.sh
@@ -34,5 +34,10 @@ export TF_VAR_cuaId=$CUSTOMER_USAGE_ATTRIBUTION_ID
 export TF_VAR_enableDevCode=$ENABLE_DEV_CODE
 export TF_VAR_video_indexer_api_version=$VIDEO_INDEXER_API_VERSION
 export TF_VAR_enableBingSafeSearch=$ENABLE_BING_SAFE_SEARCH
-# The following variables are used to configure the Azure environment specific settings
 export TF_VAR_azure_environment=$AZURE_ENVIRONMENT
+export TF_VAR_is_secure_mode=$SECURE_MODE
+export TF_VAR_enableWebChat=$ENABLE_WEB_CHAT
+export TF_VAR_enableUngroundedChat=$ENABLE_UNGROUNDED_CHAT
+export TF_VAR_enableMathTutor=$ENABLE_MATH_TUTOR
+export TF_VAR_enableCsvAgent=$ENABLE_CSV_AGENT
+export TF_VAR_enableSharePointConnector=$ENABLE_SHAREPOINT_CONNECTOR


### PR DESCRIPTION
This is a baseline PR for upcoming UX changes that will honor these feature flags. In this PR...
- Added new feature flags section in local.env.example
- Added checks in `load-env.sh` to ensure incompatible feature flags are not set
   -  Block Web Chat in US Gov (due to Bing Azure service not available)
   - Block using existing AOAI with Secure mode (to avoid changing security on an AOAI instance that may be shared with other apps)
 - Pass all feature flags into Terraform
 - Update terraform deployment to
    - Not deploy Bing resource when Web Chat feature flag is disabled
    - Not deploy SharePoint Logic App when SharePoint Connector feature flag is disabled

The following feature flags were added:
- SECURE_MODE
- ENABLE_WEB_CHAT
- ENABLE_UNGROUNDED_CHAT
- ENABLE_MATH_TUTOR
- ENABLE_CSV_AGENT
- ENABLE_SHAREPOINT_CONNECTOR