### PR TITLE
Add Chat modes to UX

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -10,9 +10,10 @@ from fastapi.staticfiles import StaticFiles
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import RedirectResponse
 import openai
-from approaches.chatrrrbingcompare import ChatReadRetrieveReadBingCompare
-from approaches.chatbingsearchcompare import ChatBingSearchCompare
+from approaches.comparewebwithwork import CompareWebWithWork
+from approaches.compareworkwithweb import CompareWorkWithWeb
 from approaches.chatreadretrieveread import ChatReadRetrieveReadApproach
+from approaches.chatwebretrieveread import ChatWebRetrieveRead
 from approaches.gpt_direct_approach import GPTDirectApproach
 from approaches.approach import Approaches
 from azure.core.credentials import AzureKeyCredential
@@ -26,7 +27,6 @@ from azure.storage.blob import (
     generate_account_sas,
 )
 from shared_code.status_log import State, StatusClassification, StatusLog, StatusQueryLevel
-from approaches.chatbingsearch import ChatBingSearch
 from azure.cosmos import CosmosClient
 
 
@@ -192,7 +192,7 @@ chat_approaches = {
                                     ENV["AZURE_AI_TRANSLATION_DOMAIN"],
                                     str_to_bool.get(ENV["USE_SEMANTIC_RERANKER"])
                                 ),
-    Approaches.ChatBingSearch: ChatBingSearch(
+    Approaches.ChatWebRetrieveRead: ChatWebRetrieveRead(
                                     model_name,
                                     ENV["AZURE_OPENAI_CHATGPT_DEPLOYMENT"],
                                     ENV["TARGET_TRANSLATION_LANGUAGE"],
@@ -200,7 +200,7 @@ chat_approaches = {
                                     ENV["BING_SEARCH_KEY"],
                                     str_to_bool.get(ENV["ENABLE_BING_SAFE_SEARCH"])
     ),
-    Approaches.ChatBingSearchCompare: ChatBingSearchCompare( 
+    Approaches.CompareWorkWithWeb: CompareWorkWithWeb( 
                                     model_name,
                                     ENV["AZURE_OPENAI_CHATGPT_DEPLOYMENT"],
                                     ENV["TARGET_TRANSLATION_LANGUAGE"],
@@ -208,9 +208,9 @@ chat_approaches = {
                                     ENV["BING_SEARCH_KEY"],
                                     str_to_bool.get(ENV["ENABLE_BING_SAFE_SEARCH"])
     ),
-    Approaches.BingRRRCompare: ChatReadRetrieveReadBingCompare(
+    Approaches.CompareWebWithWork: CompareWebWithWork(
                                     search_client,
-                                    ENV["AZURE_OPENAI_SERVICE"],
+                                    ENV["AZURE_OPENAI_ENDPOINT"],
                                     ENV["AZURE_OPENAI_SERVICE_KEY"],
                                     ENV["AZURE_OPENAI_CHATGPT_DEPLOYMENT"],
                                     ENV["KB_FIELDS_SOURCEFILE"],

--- a/app/backend/approaches/approach.py
+++ b/app/backend/approaches/approach.py
@@ -11,9 +11,9 @@ class Approaches(Enum):
     ReadRetrieveRead = 1
     ReadDecomposeAsk = 2
     GPTDirect = 3
-    ChatBingSearch = 4
-    ChatBingSearchCompare = 5
-    BingRRRCompare = 6
+    ChatWebRetrieveRead = 4
+    CompareWorkWithWeb = 5
+    CompareWebWithWork = 6
 
 class Approach:
     """

--- a/app/backend/approaches/chatwebretrieveread.py
+++ b/app/backend/approaches/chatwebretrieveread.py
@@ -13,7 +13,7 @@ from approaches.approach import Approach
 from core.messagebuilder import MessageBuilder
 from core.modelhelper import get_token_limit
 
-class ChatBingSearch(Approach):
+class ChatWebRetrieveRead(Approach):
     """Class to help perform RAG based on Bing Search and ChatGPT."""
 
     SYSTEM_MESSAGE_CHAT_CONVERSATION = """You are an Azure OpenAI Completion system. Your persona is {systemPersona} who helps answer questions. {response_length_prompt}

--- a/app/backend/approaches/comparewebwithwork.py
+++ b/app/backend/approaches/comparewebwithwork.py
@@ -14,13 +14,13 @@ from azure.storage.blob import (
 )
 from core.modelhelper import get_token_limit
 
-class ChatReadRetrieveReadBingCompare(Approach):
+class CompareWebWithWork(Approach):
     """
-    Approach for comparing and contrasting answers from internal data and Bing Chat.
+    Approach for comparing and contrasting generative response answers based on web search results vs. based on work search results.
     """
 
     COMPARATIVE_SYSTEM_MESSAGE_CHAT_CONVERSATION = """You are an Azure OpenAI Completion system. Your persona is {systemPersona}. User persona is {userPersona}.
-    Compare and contrast the answers provided below from two sources of data. The first source is internal data indexed using a RAG pattern while the second source is from Bing Chat.
+    Compare and contrast the answers provided below from two sources of data. The first source is Web where data is retrieved from an internet search while the second source is Work where internal data indexed using a RAG pattern.
     Only explain the differences between the two sources and nothing else. Do not provide personal opinions or assumptions.
     Only answer in the language {query_term_language}.
     If you cannot find answer in below sources, respond with I am not sure. Do not provide personal opinions or assumptions.
@@ -29,8 +29,8 @@ class ChatReadRetrieveReadBingCompare(Approach):
     """
 
     COMPARATIVE_RESPONSE_PROMPT_FEW_SHOTS = [
-        {"role": Approach.USER ,'content': 'I am looking for comparative information in the Bing Search Response and want to compare against the Internal Documents'},
-        {'role': Approach.ASSISTANT, 'content': 'user is looking to compare information in Bing Search Response against Internal Documents.'}
+        {"role": Approach.USER ,'content': 'I am looking for comparative information on an answer based on Web search results and want to compare against an answer based on Work internal documents'},
+        {'role': Approach.ASSISTANT, 'content': 'User is looking to compare an answer based on Web search results against an answer based on Work internal documents.'}
     ]
 
     citations = {}
@@ -82,7 +82,7 @@ class ChatReadRetrieveReadBingCompare(Approach):
 
     async def run(self, history: Sequence[dict[str, str]], overrides: dict[str, Any]) -> Any:
         """
-        Runs the approach to compare and contrast answers from internal data and Bing Chat.
+        Runs the approach to compare and contrast answers from internal data and Web Search results.
 
         Args:
             history (Sequence[dict[str, str]]): The conversation history.
@@ -118,13 +118,13 @@ class ChatReadRetrieveReadBingCompare(Approach):
         self.citations = rrr_response.get("citation_lookup")
 
         user_query = history[-1].get("user")
-        bing_answer = history[0].get("bot")
+        web_answer = history[0].get("bot")
         user_persona = overrides.get("user_persona", "")
         system_persona = overrides.get("system_persona", "")
         response_length = int(overrides.get("response_length") or 1024)
 
         # Step 2: Contruct the comparative system message with passed Rag response and Bing Search Response from above approach
-        bing_compare_query = user_query + "Internal Documents:\n" + rrr_response.get("answer") + "\n\n" + " Bing Search Response:\n" + bing_answer + "\n\n"
+        bing_compare_query = user_query + " Web search resutls:\n" + web_answer + "\n\n" + "Work internal Documents:\n" + rrr_response.get("answer") + "\n\n"
 
         messages = self.get_messages_builder(
             self.COMPARATIVE_SYSTEM_MESSAGE_CHAT_CONVERSATION.format(

--- a/app/backend/approaches/compareworkwithweb.py
+++ b/app/backend/approaches/compareworkwithweb.py
@@ -5,19 +5,19 @@ import os
 from typing import Any, Sequence
 import urllib.parse
 import openai
-from approaches.chatbingsearch import ChatBingSearch
+from approaches.chatwebretrieveread import ChatWebRetrieveRead
 from approaches.approach import Approach
 from core.messagebuilder import MessageBuilder
 from core.modelhelper import get_token_limit
 
 
-class ChatBingSearchCompare(Approach):
+class CompareWorkWithWeb(Approach):
     """
-    Approach class for performing comparative analysis between Bing Search Response and Internal Documents.
+    Approach class for performing comparative analysis between Generative answer responses based on Bing search results vs. work internal document search results.
     """
 
     COMPARATIVE_SYSTEM_MESSAGE_CHAT_CONVERSATION = """You are an Azure OpenAI Completion system. Your persona is {systemPersona}. User persona is {userPersona}.
-    Compare and contrast the answers provided below from two sources of data. The first source is internal data indexed using a RAG pattern while the second source is from Bing Chat.
+    Compare and contrast the answers provided below from two sources of data. The first source is Work where internal data is indexed using a RAG pattern while the second source Web where results are from an internet search.
     Only explain the differences between the two sources and nothing else. Do not provide personal opinions or assumptions.
     Only answer in the language {query_term_language}.
     If you cannot find answer in below sources, respond with I am not sure. Do not provide personal opinions or assumptions.
@@ -26,22 +26,25 @@ class ChatBingSearchCompare(Approach):
     """
 
     COMPARATIVE_RESPONSE_PROMPT_FEW_SHOTS = [
-        {"role": Approach.USER ,'content': 'I am looking for comparative information in the Bing Search Response and want to compare against the Internal Documents'},
-        {'role': Approach.ASSISTANT, 'content': 'user is looking to compare information in Bing Search Response against Internal Documents.'}
+        {"role": Approach.USER ,'content': 'I am looking for comparative information on an answer based on Work internal documents and want to compare against an answer based on Web search results'},
+        {'role': Approach.ASSISTANT, 'content': 'User is looking to compare an answer based on Work internal documents against an answer based on Web search results.'}
     ]
 
     citations = {}
 
     def __init__(self, model_name: str, chatgpt_deployment: str, query_term_language: str, bing_search_endpoint: str, bing_search_key: str, bing_safe_search: bool):
         """
-        Initializes the ChatBingSearchCompare approach.
+        Initializes the CompareWorkWithWeb approach.
 
         Args:
             model_name (str): The name of the model to be used for chat-based language model.
             chatgpt_deployment (str): The deployment ID of the chat-based language model.
             query_term_language (str): The language to be used for querying the data.
+            bing_search_endpoint (str): The endpoint for the Bing Search API.
+            bing_search_key (str): The API key for the Bing Search API.
+            bing_safe_search (bool): The flag to enable or disable safe search for the Bing Search API.
         """
-        self.name = "ChatBingSearchCompare"
+        self.name = "CompareWorkWithWeb"
         self.model_name = model_name
         self.chatgpt_deployment = chatgpt_deployment
         self.query_term_language = query_term_language
@@ -62,7 +65,7 @@ class ChatBingSearchCompare(Approach):
             Any: The result of the comparative analysis.
         """
         # Step 1: Call bing Search Approach for a Bing LLM Response and Citations
-        chat_bing_search = ChatBingSearch(self.model_name, self.chatgpt_deployment, self.query_term_language, self.bing_search_endpoint, self.bing_search_key, self.bing_safe_search)
+        chat_bing_search = ChatWebRetrieveRead(self.model_name, self.chatgpt_deployment, self.query_term_language, self.bing_search_endpoint, self.bing_search_key, self.bing_safe_search)
         bing_search_response = await chat_bing_search.run(history, overrides)
         self.citations = bing_search_response.get("citation_lookup")
 
@@ -73,7 +76,7 @@ class ChatBingSearchCompare(Approach):
         response_length = int(overrides.get("response_length") or 1024)
 
         # Step 2: Contruct the comparative system message with passed Rag response and Bing Search Response from above approach
-        bing_compare_query = user_query + "Internal Documents:\n" + rag_answer + "\n\n" + " Bing Search Response:\n" + bing_search_response.get("answer") + "\n\n"
+        bing_compare_query = user_query + "Work internal documents:\n" + rag_answer + "\n\n" + " Web search results:\n" + bing_search_response.get("answer") + "\n\n"
 
         messages = self.get_messages_builder(
             self.COMPARATIVE_SYSTEM_MESSAGE_CHAT_CONVERSATION.format(
@@ -93,9 +96,9 @@ class ChatBingSearchCompare(Approach):
         msg_to_display = '\n\n'.join([str(message) for message in messages])
 
         # Step 3: Final comparative analysis using OpenAI Chat Completion
-        bing_compare_resp = await self.make_chat_completion(messages)
+        compare_resp = await self.make_chat_completion(messages)
 
-        final_response = f"{urllib.parse.unquote(bing_compare_resp)}"
+        final_response = f"{urllib.parse.unquote(compare_resp)}"
 
         # Step 4: Append web citations from the Bing Search approach
         for idx, url in enumerate(self.citations.keys(), start=1):

--- a/app/frontend/src/api/models.ts
+++ b/app/frontend/src/api/models.ts
@@ -1,7 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { string } from "prop-types";
+export const enum ChatMode {
+    WorkOnly = 0,
+    WorkPlusWeb = 1,
+    Ungrounded = 2
+}
 
 export const enum Approaches {
     RetrieveThenRead = 0,

--- a/app/frontend/src/api/models.ts
+++ b/app/frontend/src/api/models.ts
@@ -8,9 +8,9 @@ export const enum Approaches {
     ReadRetrieveRead = 1,
     ReadDecomposeAsk = 2,
     GPTDirect = 3,
-    BingSearch = 4,
-    BingSearchCompare = 5,
-    BingRRRCompare = 6
+    ChatWebRetrieveRead = 4,
+    CompareWorkWithWeb = 5,
+    CompareWebWithWork = 6
 }
 
 export type AskRequestOverrides = {
@@ -43,8 +43,7 @@ export type AskResponse = {
     answer: string;
     thoughts: string | null;
     data_points: string[];
-    source: string;
-    comparative: boolean;
+    approach: Approaches;
     // citation_lookup: {}
     // added this for citation bug. aparmar.
     citation_lookup: { [key: string]: { citation: string; source_path: string; page_number: string } };

--- a/app/frontend/src/components/Answer/Answer.module.css
+++ b/app/frontend/src/components/Answer/Answer.module.css
@@ -9,20 +9,28 @@
     outline: transparent solid 1px;
 }
 
-.bingAnswerContainer {
+.answerContainerWork {
     padding: 20px;
-    background: rgb(180, 199, 221);
+    background: rgb(249, 249, 249);
     border-radius: 8px;
     box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.14), 0px 0px 2px rgba(0, 0, 0, 0.12);
-    outline: transparent solid 1px;
+    outline: #1B4AEF solid 1px;
 }
 
-.comparativeAnswerContainer {
+.answerContainerWeb {
     padding: 20px;
-    background: rgb(183, 199, 188);
+    background: rgb(249, 249, 249);
     border-radius: 8px;
     box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.14), 0px 0px 2px rgba(0, 0, 0, 0.12);
-    outline: transparent solid 1px;
+    outline: #188d45 solid 1px;
+}
+
+.answerContainerCompare {
+    padding: 20px;
+    background: rgb(249, 249, 249);
+    border-radius: 8px;
+    box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.14), 0px 0px 2px rgba(0, 0, 0, 0.12);
+    outline: #ce7b2e solid 1px;
 }
 
 .warningText {
@@ -32,8 +40,31 @@
     text-align: center;
 }
 
-.answerLogo {
-    font-size: 28px;
+.answerLogoWeb {
+    font-size: 22px;
+    color: #188d45;
+    white-space: break-spaces;
+    word-break: break-word;
+    display: flex;
+    align-items: center;
+}
+
+.answerLogoWork {
+    font-size: 22px;
+    color: #1B4AEF;
+    white-space: break-spaces;
+    word-break: break-word;
+    display: flex;
+    align-items: center;
+}
+
+.answerLogoCompare {
+    font-size: 22px;
+    color: #ce7b2e;
+    white-space: break-spaces;
+    word-break: break-word;
+    display: flex;
+    align-items: center;
 }
 
 .answerText {
@@ -55,7 +86,7 @@
     line-height: 24px;
 }
 
-.citation {
+.citationWork {
     font-weight: 500;
     line-height: 24px;
     text-align: center;
@@ -67,7 +98,39 @@
     cursor: pointer;
 }
 
-.citation:hover {
+.citationWork:hover {
+    text-decoration: underline;
+}
+
+.citationWeb {
+    font-weight: 500;
+    line-height: 24px;
+    text-align: center;
+    border-radius: 4px;
+    padding: 0px 8px;
+    background: #d1fad8;
+    color: #123bb6;
+    text-decoration: none;
+    cursor: pointer;
+}
+
+.citationWeb:hover {
+    text-decoration: underline;
+}
+
+.citationCompare {
+    font-weight: 500;
+    line-height: 24px;
+    text-align: center;
+    border-radius: 4px;
+    padding: 0px 8px;
+    background: #fae3d1;
+    color: #123bb6;
+    text-decoration: none;
+    cursor: pointer;
+}
+
+.citationCompare:hover {
     text-decoration: underline;
 }
 
@@ -148,4 +211,17 @@ sup {
 .loadingdots::after {
     content: "";
     animation: loading 1s infinite;
+}
+
+.raiwarning {
+    font-size: 12px;
+    font-weight: 400;
+    color: rgb(133, 133, 133);
+    line-height: 22px;
+    padding-top: 6px;
+    padding-bottom: 6px;
+    white-space: pre-line;
+    display: flex;
+    align-items: center;
+    flex-direction: column;
 }

--- a/app/frontend/src/components/Answer/Answer.module.css
+++ b/app/frontend/src/components/Answer/Answer.module.css
@@ -33,6 +33,12 @@
     outline: #ce7b2e solid 1px;
 }
 
+.answerContainerUngrounded {
+    padding: 20px;
+    background: transparent;
+    outline: transparent;
+}
+
 .warningText {
     color: rgb(182, 91, 114);
     font-weight: bold;
@@ -67,6 +73,23 @@
     align-items: center;
 }
 
+.answerLogoUngrounded {
+    font-size: 22px;
+    color: rgba(0, 0, 0, 1);
+    white-space: break-spaces;
+    word-break: break-word;
+    display: flex;
+    align-items: center;
+}
+
+.answerLogoUngroundedText {
+    padding-left: 10px;
+    font-size: 16px;
+    line-height: 22px;
+    font-weight: 700;
+    font-variation-settings: unset;
+}
+
 .answerText {
     font-size: 16px;
     font-weight: 400;
@@ -74,6 +97,16 @@
     padding-top: 16px;
     padding-bottom: 16px;
     white-space: pre-line;
+}
+
+.answerTextUngrounded {
+    font-size: 16px;
+    font-weight: 400;
+    line-height: 22px;
+    padding-top: 16px;
+    padding-bottom: 16px;
+    white-space: pre-line;
+    padding-left: 36px;
 }
 
 .selected {

--- a/app/frontend/src/components/Answer/Answer.tsx
+++ b/app/frontend/src/components/Answer/Answer.tsx
@@ -2,12 +2,13 @@
 // Licensed under the MIT license.
 
 import { useMemo } from "react";
-import { Stack, IconButton, Icon } from "@fluentui/react";
+import { Stack, IconButton } from "@fluentui/react";
+import { ShieldCheckmark20Regular } from '@fluentui/react-icons';
 import DOMPurify from "dompurify";
 
 import styles from "./Answer.module.css";
 
-import { AskResponse, getCitationFilePath } from "../../api";
+import { Approaches, AskResponse, getCitationFilePath } from "../../api";
 import { parseAnswerToHtml } from "./AnswerParser";
 import { AnswerIcon } from "./AnswerIcon";
 import { RAIPanel } from "../RAIPanel";
@@ -17,9 +18,9 @@ interface Props {
     isSelected?: boolean;
     onCitationClicked: (filePath: string, sourcePath: string, pageNumber: string) => void;
     onThoughtProcessClicked: () => void;
-    onBingSearchClicked: () => void;
+    onWebSearchClicked: () => void;
     onRagSearchClicked: () => void;
-    onBingCompareClicked: () => void;
+    onWebCompareClicked: () => void;
     onRagCompareClicked: () => void;
     onSupportingContentClicked: () => void;
     onFollowupQuestionClicked?: (question: string) => void;
@@ -33,9 +34,9 @@ export const Answer = ({
     isSelected,
     onCitationClicked,
     onThoughtProcessClicked,
-    onBingSearchClicked,
+    onWebSearchClicked,
     onRagSearchClicked,
-    onBingCompareClicked,
+    onWebCompareClicked,
     onRagCompareClicked,
     onSupportingContentClicked,
     onFollowupQuestionClicked,
@@ -43,15 +44,18 @@ export const Answer = ({
     onAdjustClick,
     onRegenerateClick
 }: Props) => {
-    const parsedAnswer = useMemo(() => parseAnswerToHtml(answer.answer, answer.source, answer.citation_lookup, onCitationClicked), [answer]);
+    const parsedAnswer = useMemo(() => parseAnswerToHtml(answer.answer, answer.approach, answer.citation_lookup, onCitationClicked), [answer]);
 
     const sanitizedAnswerHtml = DOMPurify.sanitize(parsedAnswer.answerHtml);
 
     return (
-        <Stack className={`${answer.comparative ? styles.comparativeAnswerContainer : (answer.source === 'bing' ? styles.bingAnswerContainer : styles.answerContainer)} ${isSelected && styles.selected}`} verticalAlign="space-between">
+        <Stack className={`${answer.approach == Approaches.ReadRetrieveRead ? styles.answerContainerWork : 
+                            answer.approach == Approaches.ChatWebRetrieveRead ? styles.answerContainerWeb :
+                            answer.approach == Approaches.CompareWorkWithWeb || answer.approach == Approaches.CompareWebWithWork ? styles.answerContainerCompare :
+                            styles.answerContainer} ${isSelected && styles.selected}`} verticalAlign="space-between">
             <Stack.Item>
                 <Stack horizontal horizontalAlign="space-between">
-                    <AnswerIcon source={answer.source} />
+                    <AnswerIcon approach={answer.approach} />
                     <div>
                         <IconButton
                             style={{ color: "black" }}
@@ -61,7 +65,7 @@ export const Answer = ({
                             onClick={() => onThoughtProcessClicked()}
                             disabled={!answer.thoughts}
                         />
-                        {answer.source !== 'bing' && !answer.comparative &&
+                        {answer.approach == Approaches.ReadRetrieveRead &&
                             <IconButton
                                 style={{ color: "black" }}
                                 iconProps={{ iconName: "ClipboardList" }}
@@ -76,9 +80,9 @@ export const Answer = ({
             </Stack.Item>
 
             <Stack.Item grow>
-                {answer.source === 'bing' &&
-                    <div className={styles.warningText}>
-                        ****Warning: This response is from the internet using Bing****
+                {(answer.approach == Approaches.ChatWebRetrieveRead || answer.approach == Approaches.CompareWorkWithWeb) &&
+                    <div className={styles.protectedBanner}>
+                        <ShieldCheckmark20Regular></ShieldCheckmark20Regular>Your personal and company data are protected
                     </div>
                 }
                 <div className={styles.answerText} dangerouslySetInnerHTML={{ __html: sanitizedAnswerHtml }}></div>
@@ -91,15 +95,23 @@ export const Answer = ({
                         {parsedAnswer.citations.map((x, i) => {
                             const path = getCitationFilePath(x);
                             return (
-                                <a key={i} className={styles.citation} title={x} onClick={() => onCitationClicked(path, (parsedAnswer.sourceFiles as any)[x], (parsedAnswer.pageNumbers as any)[x])}>
+                                (parsedAnswer.approach == Approaches.ChatWebRetrieveRead || parsedAnswer.approach == Approaches.CompareWorkWithWeb) ? 
+                                    <a key={i} className={parsedAnswer.approach == Approaches.ChatWebRetrieveRead ? styles.citationWeb : styles.citationCompare} 
+                                    title={x} href={'https://'+ x} target="_blank" rel="noopener noreferrer">
                                     {`${++i}. ${x}`}
+                                    </a>
+                                 : 
+                                 <a key={i} className={parsedAnswer.approach == Approaches.ReadRetrieveRead ? styles.citationWork : styles.citationCompare} 
+                                 title={x} onClick={() => onCitationClicked(path, (parsedAnswer.sourceFiles as any)[x], (parsedAnswer.pageNumbers as any)[x])}>
+                                 {`${++i}. ${x}`}
                                 </a>
                             );
                         })}
                     </Stack>
                 </Stack.Item>
+                
             )}
-
+            
             {!!parsedAnswer.followupQuestions.length && showFollowupQuestions && onFollowupQuestionClicked && (
                 <Stack.Item>
                     <Stack horizontal wrap className={`${!!parsedAnswer.citations.length ? styles.followupQuestionsList : ""}`} tokens={{ childrenGap: 6 }}>
@@ -114,8 +126,11 @@ export const Answer = ({
                     </Stack>
                 </Stack.Item>
             )}
+            <Stack.Item>
+                <div className={styles.raiwarning}>AI-generated content may be incorrect</div>
+            </Stack.Item>
             <Stack.Item align="center">
-                <RAIPanel source={answer.source} comparative={answer.comparative} onAdjustClick={onAdjustClick} onRegenerateClick={onRegenerateClick} onBingSearchClicked={onBingSearchClicked} onBingCompareClicked={onBingCompareClicked} onRagCompareClicked={onRagCompareClicked} onRagSearchClicked={onRagSearchClicked} />
+                <RAIPanel approach={answer.approach} onAdjustClick={onAdjustClick} onRegenerateClick={onRegenerateClick} onWebSearchClicked={onWebSearchClicked} onWebCompareClicked={onWebCompareClicked} onRagCompareClicked={onRagCompareClicked} onRagSearchClicked={onRagSearchClicked} />
             </Stack.Item>
         </Stack>
     );

--- a/app/frontend/src/components/Answer/Answer.tsx
+++ b/app/frontend/src/components/Answer/Answer.tsx
@@ -8,7 +8,7 @@ import DOMPurify from "dompurify";
 
 import styles from "./Answer.module.css";
 
-import { Approaches, AskResponse, getCitationFilePath } from "../../api";
+import { Approaches, AskResponse, getCitationFilePath, ChatMode } from "../../api";
 import { parseAnswerToHtml } from "./AnswerParser";
 import { AnswerIcon } from "./AnswerIcon";
 import { RAIPanel } from "../RAIPanel";
@@ -27,6 +27,7 @@ interface Props {
     showFollowupQuestions?: boolean;
     onAdjustClick?: () => void;
     onRegenerateClick?: () => void;
+    chatMode: ChatMode;
 }
 
 export const Answer = ({
@@ -42,7 +43,8 @@ export const Answer = ({
     onFollowupQuestionClicked,
     showFollowupQuestions,
     onAdjustClick,
-    onRegenerateClick
+    onRegenerateClick,
+    chatMode
 }: Props) => {
     const parsedAnswer = useMemo(() => parseAnswerToHtml(answer.answer, answer.approach, answer.citation_lookup, onCitationClicked), [answer]);
 
@@ -52,19 +54,22 @@ export const Answer = ({
         <Stack className={`${answer.approach == Approaches.ReadRetrieveRead ? styles.answerContainerWork : 
                             answer.approach == Approaches.ChatWebRetrieveRead ? styles.answerContainerWeb :
                             answer.approach == Approaches.CompareWorkWithWeb || answer.approach == Approaches.CompareWebWithWork ? styles.answerContainerCompare :
+                            answer.approach == Approaches.GPTDirect ? styles.answerContainerUngrounded :
                             styles.answerContainer} ${isSelected && styles.selected}`} verticalAlign="space-between">
             <Stack.Item>
                 <Stack horizontal horizontalAlign="space-between">
                     <AnswerIcon approach={answer.approach} />
                     <div>
-                        <IconButton
-                            style={{ color: "black" }}
-                            iconProps={{ iconName: "Lightbulb" }}
-                            title="Show thought process"
-                            ariaLabel="Show thought process"
-                            onClick={() => onThoughtProcessClicked()}
-                            disabled={!answer.thoughts}
-                        />
+                        {answer.approach != Approaches.GPTDirect && 
+                            <IconButton
+                                style={{ color: "black" }}
+                                iconProps={{ iconName: "Lightbulb" }}
+                                title="Show thought process"
+                                ariaLabel="Show thought process"
+                                onClick={() => onThoughtProcessClicked()}
+                                disabled={!answer.thoughts}
+                            />
+                        }
                         {answer.approach == Approaches.ReadRetrieveRead &&
                             <IconButton
                                 style={{ color: "black" }}
@@ -85,7 +90,7 @@ export const Answer = ({
                         <ShieldCheckmark20Regular></ShieldCheckmark20Regular>Your personal and company data are protected
                     </div>
                 }
-                <div className={styles.answerText} dangerouslySetInnerHTML={{ __html: sanitizedAnswerHtml }}></div>
+                <div className={answer.approach == Approaches.GPTDirect ? styles.answerTextUngrounded : styles.answerText} dangerouslySetInnerHTML={{ __html: sanitizedAnswerHtml }}></div>
             </Stack.Item>
 
             {!!parsedAnswer.citations.length && (
@@ -130,7 +135,7 @@ export const Answer = ({
                 <div className={styles.raiwarning}>AI-generated content may be incorrect</div>
             </Stack.Item>
             <Stack.Item align="center">
-                <RAIPanel approach={answer.approach} onAdjustClick={onAdjustClick} onRegenerateClick={onRegenerateClick} onWebSearchClicked={onWebSearchClicked} onWebCompareClicked={onWebCompareClicked} onRagCompareClicked={onRagCompareClicked} onRagSearchClicked={onRagSearchClicked} />
+                <RAIPanel approach={answer.approach} chatMode={chatMode} onAdjustClick={onAdjustClick} onRegenerateClick={onRegenerateClick} onWebSearchClicked={onWebSearchClicked} onWebCompareClicked={onWebCompareClicked} onRagCompareClicked={onRagCompareClicked} onRagSearchClicked={onRagSearchClicked} />
             </Stack.Item>
         </Stack>
     );

--- a/app/frontend/src/components/Answer/AnswerIcon.tsx
+++ b/app/frontend/src/components/Answer/AnswerIcon.tsx
@@ -1,16 +1,29 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { Sparkle28Filled } from "@fluentui/react-icons";
-import { Icon } from "@fluentui/react";
+import { DocumentLock24Filled, Globe24Filled, Link20Filled, Sparkle20Filled } from "@fluentui/react-icons";
+import { Approaches } from "../../api";
+
+import styles from "./Answer.module.css";
 
 interface AnswerIconProps {
-    source?: string;
+    approach: Approaches;
 }
 
-export const AnswerIcon: React.FC<AnswerIconProps> = ({ source }) => {
-    if (source === 'bing') {
-        return <Icon iconName="BingLogo" aria-hidden="true" aria-label="Bing logo" styles={{ root: { fontSize: '30px' } }}/>;
+export const AnswerIcon: React.FC<AnswerIconProps> = ({ approach }) => {
+    if (approach == Approaches.ChatWebRetrieveRead) {
+        return <div className={styles.answerLogoWeb}><Globe24Filled primaryFill={"rgba(24, 141, 69, 1)"} aria-hidden="true" aria-label="Web Answer logo" /> Web</div>;
+        }
+    else if (approach == Approaches.ReadRetrieveRead) {
+        return <div className={styles.answerLogoWork}><DocumentLock24Filled primaryFill={"rgba(27, 74, 239, 1)"} aria-hidden="true" aria-label="Work Answer logo" /> Work</div>;
+        }
+    else if (approach == Approaches.CompareWebWithWork) {
+        return <div className={styles.answerLogoCompare}><Globe24Filled primaryFill={"rgba(206, 123, 46, 1)"} aria-hidden="true" aria-label="Web Compared to Work Answer Logo" /><Link20Filled primaryFill={"rgba(206, 123, 46, 1)"} /><DocumentLock24Filled primaryFill={"rgba(206, 123, 46, 1)"} aria-hidden="true" /> Web compared to Work</div>;
+        }
+    else if (approach == Approaches.CompareWorkWithWeb) {
+        return <div className={styles.answerLogoCompare}><DocumentLock24Filled primaryFill={"rgba(206, 123, 46, 1)"} aria-hidden="true" aria-label="Work Compared to Web Answer logo" /><Link20Filled primaryFill={"rgba(206, 123, 46, 1)"} /><Globe24Filled primaryFill={"rgba(206, 123, 46, 1)"} aria-hidden="true" /> Work compared to Web</div>;
+        }
+    else {
+        return <Sparkle20Filled primaryFill={"rgba(115, 118, 225, 1)"}/>;
     }
-    return <Sparkle28Filled primaryFill={"rgba(115, 118, 225, 1)"} aria-hidden="true" aria-label="Answer logo" />;
 };

--- a/app/frontend/src/components/Answer/AnswerIcon.tsx
+++ b/app/frontend/src/components/Answer/AnswerIcon.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { DocumentLock24Filled, Globe24Filled, Link20Filled, Sparkle20Filled } from "@fluentui/react-icons";
+import { BuildingMultiple24Filled, Globe24Filled, Link20Filled, Sparkle24Filled } from "@fluentui/react-icons";
 import { Approaches } from "../../api";
 
 import styles from "./Answer.module.css";
@@ -15,15 +15,15 @@ export const AnswerIcon: React.FC<AnswerIconProps> = ({ approach }) => {
         return <div className={styles.answerLogoWeb}><Globe24Filled primaryFill={"rgba(24, 141, 69, 1)"} aria-hidden="true" aria-label="Web Answer logo" /> Web</div>;
         }
     else if (approach == Approaches.ReadRetrieveRead) {
-        return <div className={styles.answerLogoWork}><DocumentLock24Filled primaryFill={"rgba(27, 74, 239, 1)"} aria-hidden="true" aria-label="Work Answer logo" /> Work</div>;
+        return <div className={styles.answerLogoWork}><BuildingMultiple24Filled primaryFill={"rgba(27, 74, 239, 1)"} aria-hidden="true" aria-label="Work Answer logo" /> Work</div>;
         }
     else if (approach == Approaches.CompareWebWithWork) {
-        return <div className={styles.answerLogoCompare}><Globe24Filled primaryFill={"rgba(206, 123, 46, 1)"} aria-hidden="true" aria-label="Web Compared to Work Answer Logo" /><Link20Filled primaryFill={"rgba(206, 123, 46, 1)"} /><DocumentLock24Filled primaryFill={"rgba(206, 123, 46, 1)"} aria-hidden="true" /> Web compared to Work</div>;
+        return <div className={styles.answerLogoCompare}><Globe24Filled primaryFill={"rgba(206, 123, 46, 1)"} aria-hidden="true" aria-label="Web Compared to Work Answer Logo" /><Link20Filled primaryFill={"rgba(206, 123, 46, 1)"} /><BuildingMultiple24Filled primaryFill={"rgba(206, 123, 46, 1)"} aria-hidden="true" /> Web compared to Work</div>;
         }
     else if (approach == Approaches.CompareWorkWithWeb) {
-        return <div className={styles.answerLogoCompare}><DocumentLock24Filled primaryFill={"rgba(206, 123, 46, 1)"} aria-hidden="true" aria-label="Work Compared to Web Answer logo" /><Link20Filled primaryFill={"rgba(206, 123, 46, 1)"} /><Globe24Filled primaryFill={"rgba(206, 123, 46, 1)"} aria-hidden="true" /> Work compared to Web</div>;
+        return <div className={styles.answerLogoCompare}><BuildingMultiple24Filled primaryFill={"rgba(206, 123, 46, 1)"} aria-hidden="true" aria-label="Work Compared to Web Answer logo" /><Link20Filled primaryFill={"rgba(206, 123, 46, 1)"} /><Globe24Filled primaryFill={"rgba(206, 123, 46, 1)"} aria-hidden="true" /> Work compared to Web</div>;
         }
     else {
-        return <Sparkle20Filled primaryFill={"rgba(115, 118, 225, 1)"}/>;
+        return <div className={styles.answerLogoUngrounded}><Sparkle24Filled primaryFill={"rgba(0, 0, 0, 1)"}/><div className={styles.answerLogoUngroundedText}>Information Assistant</div></div>;
     }
 };

--- a/app/frontend/src/components/Answer/AnswerLoading.tsx
+++ b/app/frontend/src/components/Answer/AnswerLoading.tsx
@@ -6,6 +6,7 @@ import { animated, useSpring } from "@react-spring/web";
 
 import styles from "./Answer.module.css";
 import { AnswerIcon } from "./AnswerIcon";
+import { Approaches } from "../../api";
 
 export const AnswerLoading = () => {
     const animatedStyles = useSpring({
@@ -16,7 +17,7 @@ export const AnswerLoading = () => {
     return (
         <animated.div style={{ ...animatedStyles }}>
             <Stack className={styles.answerContainer} verticalAlign="space-between">
-                <AnswerIcon />
+                <AnswerIcon approach={Approaches.GPTDirect}/>
                 <Stack.Item grow>
                     <p className={styles.answerText}>
                         Generating answer

--- a/app/frontend/src/components/Answer/AnswerLoading.tsx
+++ b/app/frontend/src/components/Answer/AnswerLoading.tsx
@@ -8,7 +8,11 @@ import styles from "./Answer.module.css";
 import { AnswerIcon } from "./AnswerIcon";
 import { Approaches } from "../../api";
 
-export const AnswerLoading = () => {
+interface AnswerLoadingProps {
+    approach: Approaches;
+}
+
+export const AnswerLoading: React.FC<AnswerLoadingProps> = ({ approach }) => {
     const animatedStyles = useSpring({
         from: { opacity: 0 },
         to: { opacity: 1 }
@@ -16,10 +20,10 @@ export const AnswerLoading = () => {
 
     return (
         <animated.div style={{ ...animatedStyles }}>
-            <Stack className={styles.answerContainer} verticalAlign="space-between">
-                <AnswerIcon approach={Approaches.GPTDirect}/>
+            <Stack className={approach == Approaches.GPTDirect ? styles.answerContainerUngrounded : styles.answerContainer} verticalAlign="space-between">
+                <AnswerIcon approach={approach}/>
                 <Stack.Item grow>
-                    <p className={styles.answerText}>
+                    <p className={approach == Approaches.GPTDirect ? styles.answerTextUngrounded : styles.answerText}>
                         Generating answer
                         <span className={styles.loadingdots} />
                     </p>

--- a/app/frontend/src/components/Answer/AnswerParser.tsx
+++ b/app/frontend/src/components/Answer/AnswerParser.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { renderToStaticMarkup } from "react-dom/server";
-import { getCitationFilePath } from "../../api";
+import { getCitationFilePath, Approaches } from "../../api";
 
 type HtmlParsedAnswer = {
     answerHtml: string;
@@ -10,6 +10,7 @@ type HtmlParsedAnswer = {
     sourceFiles: Record<string, string>;
     pageNumbers: Record<string, number>;
     followupQuestions: string[];
+    approach: Approaches;
 };
 
 type CitationLookup = Record<string, {
@@ -18,7 +19,7 @@ type CitationLookup = Record<string, {
     page_number: string;
 }>;
 
-export function parseAnswerToHtml(answer: string, source: string, citation_lookup: CitationLookup, onCitationClicked: (citationFilePath: string, citationSourcePath: string, pageNumber: string) => void): HtmlParsedAnswer {
+export function parseAnswerToHtml(answer: string, approach: Approaches, citation_lookup: CitationLookup, onCitationClicked: (citationFilePath: string, citationSourcePath: string, pageNumber: string) => void): HtmlParsedAnswer {
     const citations: string[] = [];
     // const sourceFiles: {} = {};
     const sourceFiles: Record<string, string> = {};
@@ -53,12 +54,11 @@ export function parseAnswerToHtml(answer: string, source: string, citation_looku
                 return "";
             }
             else {
-                let isBing = source === "bing";
                 let citationIndex: number;
                 let citationShortName: string
                 // splitting the full file path from citation_lookup into an array and then slicing it to get the folders, file name, and extension 
                 // the first 4 elements of the full file path are the "https:", "", "blob storaage url", and "container name" which are not needed in the display
-                if (isBing){
+                if (approach == Approaches.ChatWebRetrieveRead || approach == Approaches.CompareWorkWithWeb) {
                     citationShortName = new URL(citation.citation).hostname;
                 }else{
                     citationShortName = (citation_lookup)[part].citation.split("/").slice(4).join("/");
@@ -85,7 +85,7 @@ export function parseAnswerToHtml(answer: string, source: string, citation_looku
                         pageNumbers[citationShortName] = NaN;
                     }
                 }
-                if (isBing) {
+                if (approach == Approaches.ChatWebRetrieveRead || approach == Approaches.CompareWorkWithWeb) {
                     return renderToStaticMarkup(
                         <a className="supContainer" title={citationShortName} href={citation.citation} target="_blank" rel="noopener noreferrer">
                             <sup>{citationIndex}</sup>
@@ -111,6 +111,7 @@ export function parseAnswerToHtml(answer: string, source: string, citation_looku
         citations,
         sourceFiles,
         pageNumbers,
-        followupQuestions
+        followupQuestions,
+        approach
     };
 }

--- a/app/frontend/src/components/ChatModeButtonGroup/ChatModeButtonGroup.module.css
+++ b/app/frontend/src/components/ChatModeButtonGroup/ChatModeButtonGroup.module.css
@@ -1,0 +1,174 @@
+/* Copyright (c) Microsoft Corporation.
+   Licensed under the MIT license. */
+
+.container {
+    cursor: pointer;
+}
+
+.disabled {
+    opacity: 0.4;
+}
+
+.buttonGroup {
+    display: inline-flex;
+    opacity: 1;
+    transition-property: opacity, inset-inline-start;
+    transition-timing-function: linear;
+    flex-direction: row;
+    width: fit-content;
+    border-radius: 40px;
+    border: 1px solid rgba(0, 0, 0, .04);
+    background: #ddd;
+    justify-content: space-between;
+    vertical-align: middle;
+    padding: 2px;
+    gap: 2px;
+    cursor: pointer;
+    margin: 2px 6px 2px 2px;
+    position: relative;
+    align-items: center;
+}
+
+.buttonleft {
+    padding-inline-end: 10px;
+    display: flex;
+    padding: 6px 0;
+    justify-content: center;
+    align-items: center;
+    gap: 4px;
+    color: #444;
+    font-size: 11px;
+    font-style: normal;
+    font-weight: 400;
+    font-family: inherit;
+    line-height: 24px;
+    width: fit-content;
+    height: 24px;
+    padding-inline: 12px;
+    pointer-events: auto;
+    text-decoration: none;
+    min-width: 46px;
+    border: transparent;
+    background: transparent;
+  }
+  
+  .buttonleftactive {
+    padding-inline: 12px !important;    
+    display: flex;
+    padding: 6px;
+    justify-content: center;
+    align-items: center;
+    gap: 4px;
+    color: #111;
+    font-size: 11px;
+    font-style: normal;
+    font-weight: 600;
+    font-family: inherit;
+    line-height: 24px;
+    width: fit-content;
+    height: 24px;
+    padding-inline: 12px;
+    pointer-events: none;
+    text-decoration: none;
+    min-width: 46px;
+    background: #fff;
+    box-shadow: 0 1.6px 3.6px 0 rgba(0,0,0,.13), 0 0.3px 0.9px 0 rgba(0,0,0,.1);
+    border-radius: 40px;
+    border: transparent;
+  }
+
+  .buttonright {
+    padding-inline-end: 10px;
+    display: flex;
+    padding: 6px 0;
+    justify-content: center;
+    align-items: center;
+    gap: 4px;
+    color: #444;
+    font-size: 11px;
+    font-style: normal;
+    font-weight: 400;
+    font-family: inherit;
+    line-height: 24px;
+    width: fit-content;
+    height: 24px;
+    padding-inline: 12px;
+    pointer-events: auto;
+    text-decoration: none;
+    min-width: 46px;
+    border: transparent;
+    background: transparent;
+  }
+
+  .buttonrightactive {
+    padding-inline: 12px !important;    
+    display: flex;
+    padding: 6px;
+    justify-content: center;
+    align-items: center;
+    gap: 4px;
+    color: #111;
+    font-size: 11px;
+    font-style: normal;
+    font-weight: 600;
+    font-family: inherit;
+    line-height: 24px;
+    width: fit-content;
+    height: 24px;
+    padding-inline: 12px;
+    pointer-events: none;
+    text-decoration: none;
+    min-width: 46px;
+    background: #fff;
+    box-shadow: 0 1.6px 3.6px 0 rgba(0,0,0,.13), 0 0.3px 0.9px 0 rgba(0,0,0,.1);
+    border-radius: 40px;
+    border: transparent;
+  }
+
+  .buttonmiddle {
+    padding-inline-end: 10px;
+    display: flex;
+    padding: 6px 0;
+    justify-content: center;
+    align-items: center;
+    gap: 4px;
+    color: #444;
+    font-size: 11px;
+    font-style: normal;
+    font-weight: 400;
+    font-family: inherit;
+    line-height: 24px;
+    width: fit-content;
+    height: 24px;
+    padding-inline: 12px;
+    pointer-events: auto;
+    text-decoration: none;
+    min-width: 46px;
+    border: transparent;
+    background: transparent;
+  }
+
+  .buttonmiddleactive {
+    padding-inline: 12px !important;    
+    display: flex;
+    padding: 6px;
+    justify-content: center;
+    align-items: center;
+    gap: 4px;
+    color: #111;
+    font-size: 11px;
+    font-style: normal;
+    font-weight: 600;
+    font-family: inherit;
+    line-height: 24px;
+    width: fit-content;
+    height: 24px;
+    padding-inline: 12px;
+    pointer-events: none;
+    text-decoration: none;
+    min-width: 46px;
+    background: #fff;
+    box-shadow: 0 1.6px 3.6px 0 rgba(0,0,0,.13), 0 0.3px 0.9px 0 rgba(0,0,0,.1);
+    border-radius: 40px;
+    border: transparent;
+  }

--- a/app/frontend/src/components/ChatModeButtonGroup/ChatModeButtonGroup.tsx
+++ b/app/frontend/src/components/ChatModeButtonGroup/ChatModeButtonGroup.tsx
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { Button, ButtonGroup } from "react-bootstrap";
+import { ChatMode } from "../../api";
+
+import styles from "./ChatModeButtonGroup.module.css";
+
+interface Props {
+    className?: string;
+    onClick: (_ev: any) => void;
+    defaultValue?: ChatMode;
+}
+
+export const ChatModeButtonGroup = ({ className, onClick, defaultValue }: Props) => {
+    return (
+        <div className={`${styles.container} ${className ?? ""}`}>
+            <ButtonGroup className={`${styles.buttonGroup}`} onClick={onClick} bsPrefix="ia">
+                <Button className={`${defaultValue == ChatMode.WorkOnly? styles.buttonleftactive : styles.buttonleft ?? ""}`} size="sm" value={0} bsPrefix='ia'>{"Work Only"}</Button>
+                <Button className={`${defaultValue == ChatMode.WorkPlusWeb? styles.buttonmiddleactive : styles.buttonmiddle ?? ""}`} size="sm" value={1} bsPrefix='ia'>{"Work + Web"}</Button>
+                <Button className={`${defaultValue == ChatMode.Ungrounded? styles.buttonrightactive : styles.buttonright ?? ""}`} size="sm" value={2} bsPrefix='ia'>{"Generative (Ungrounded)"}</Button>
+            </ButtonGroup>
+        </div>
+    );
+};

--- a/app/frontend/src/components/ChatModeButtonGroup/index.tsx
+++ b/app/frontend/src/components/ChatModeButtonGroup/index.tsx
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+export * from "./ChatModeButtonGroup";

--- a/app/frontend/src/components/RAIPanel/RAIPanel.tsx
+++ b/app/frontend/src/components/RAIPanel/RAIPanel.tsx
@@ -1,23 +1,23 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { Options16Filled, ArrowSync16Filled, DatabaseStack16Filled } from "@fluentui/react-icons";
+import { Options16Filled, ArrowSync16Filled, Briefcase16Filled, Globe16Filled } from "@fluentui/react-icons";
 
 import styles from "./RAIPanel.module.css";
 import { Icon } from "@fluentui/react";
+import { Approaches } from "../../api";
 
 interface Props {
-    source?: string;
-    comparative?: boolean;
+    approach?: Approaches;
     onAdjustClick?: () => void;
     onRegenerateClick?: () => void;
-    onBingSearchClicked?: () => void;
+    onWebSearchClicked?: () => void;
     onRagSearchClicked?: () => void;
-    onBingCompareClicked?: () => void;
+    onWebCompareClicked?: () => void;
     onRagCompareClicked?: () => void;
 }
 
-export const RAIPanel = ({ source, comparative, onAdjustClick, onRegenerateClick, onBingSearchClicked, onRagSearchClicked, onBingCompareClicked, onRagCompareClicked }: Props) => {
+export const RAIPanel = ({approach, onAdjustClick, onRegenerateClick, onWebSearchClicked, onRagSearchClicked, onWebCompareClicked, onRagCompareClicked }: Props) => {
     return (
         <div className={styles.adjustInputContainer}>
             <div className={styles.adjustInput} onClick={onAdjustClick}>
@@ -28,31 +28,30 @@ export const RAIPanel = ({ source, comparative, onAdjustClick, onRegenerateClick
                 <ArrowSync16Filled primaryFill="rgba(133, 133, 133, 1)" />
                 <span className={styles.adjustInputText}>Regenerate</span>
             </div>
-            {!comparative && (
-                source === 'bing' ? (
+            {approach == Approaches.ChatWebRetrieveRead &&
                     <>
                         <div className={styles.adjustInput} onClick={onRagSearchClicked}>
-                            <DatabaseStack16Filled primaryFill="rgba(133, 133, 133, 1)" />
-                            <span className={styles.adjustInputText}>Search Data</span>
+                            <Briefcase16Filled primaryFill="rgba(133, 133, 133, 1)" />
+                            <span className={styles.adjustInputText}>Search Work</span>
                         </div>
                         <div className={styles.adjustInput} onClick={onRagCompareClicked}>
-                            <DatabaseStack16Filled primaryFill="rgba(133, 133, 133, 1)" />
-                            <span className={styles.adjustInputText}>Compare Data</span>
+                            <Briefcase16Filled primaryFill="rgba(133, 133, 133, 1)" />
+                            <span className={styles.adjustInputText}>Compare with Work</span>
                         </div>
                     </>
-                ) : (
+            }
+            {approach == Approaches.ReadRetrieveRead &&
                     <>
-                        <div className={styles.adjustInput} onClick={onBingSearchClicked}>
-                            <Icon iconName={"BingLogo"} />
-                            <span className={styles.adjustInputText}>Search Bing</span>
+                        <div className={styles.adjustInput} onClick={onWebSearchClicked}>
+                            <Globe16Filled primaryFill="rgba(133, 133, 133, 1)" />
+                            <span className={styles.adjustInputText}>Search Web</span>
                         </div>
-                        <div className={styles.adjustInput} onClick={onBingCompareClicked}>
-                            <Icon iconName={"BingLogo"} />
-                            <span className={styles.adjustInputText}>Compare Bing</span>
+                        <div className={styles.adjustInput} onClick={onWebCompareClicked}>
+                            <Globe16Filled primaryFill="rgba(133, 133, 133, 1)" />
+                            <span className={styles.adjustInputText}>Compare with Web</span>
                         </div>
                     </>
-                )
-            )}
+            }
         </div>
     );
 };

--- a/app/frontend/src/components/RAIPanel/RAIPanel.tsx
+++ b/app/frontend/src/components/RAIPanel/RAIPanel.tsx
@@ -5,10 +5,11 @@ import { Options16Filled, ArrowSync16Filled, Briefcase16Filled, Globe16Filled } 
 
 import styles from "./RAIPanel.module.css";
 import { Icon } from "@fluentui/react";
-import { Approaches } from "../../api";
+import { Approaches, ChatMode } from "../../api";
 
 interface Props {
     approach?: Approaches;
+    chatMode?: ChatMode;
     onAdjustClick?: () => void;
     onRegenerateClick?: () => void;
     onWebSearchClicked?: () => void;
@@ -17,7 +18,7 @@ interface Props {
     onRagCompareClicked?: () => void;
 }
 
-export const RAIPanel = ({approach, onAdjustClick, onRegenerateClick, onWebSearchClicked, onRagSearchClicked, onWebCompareClicked, onRagCompareClicked }: Props) => {
+export const RAIPanel = ({approach, chatMode, onAdjustClick, onRegenerateClick, onWebSearchClicked, onRagSearchClicked, onWebCompareClicked, onRagCompareClicked }: Props) => {
     return (
         <div className={styles.adjustInputContainer}>
             <div className={styles.adjustInput} onClick={onAdjustClick}>
@@ -28,7 +29,7 @@ export const RAIPanel = ({approach, onAdjustClick, onRegenerateClick, onWebSearc
                 <ArrowSync16Filled primaryFill="rgba(133, 133, 133, 1)" />
                 <span className={styles.adjustInputText}>Regenerate</span>
             </div>
-            {approach == Approaches.ChatWebRetrieveRead &&
+            {(approach == Approaches.ChatWebRetrieveRead && chatMode == ChatMode.WorkPlusWeb) &&
                     <>
                         <div className={styles.adjustInput} onClick={onRagSearchClicked}>
                             <Briefcase16Filled primaryFill="rgba(133, 133, 133, 1)" />
@@ -40,7 +41,7 @@ export const RAIPanel = ({approach, onAdjustClick, onRegenerateClick, onWebSearc
                         </div>
                     </>
             }
-            {approach == Approaches.ReadRetrieveRead &&
+            {(approach == Approaches.ReadRetrieveRead && chatMode == ChatMode.WorkPlusWeb) &&
                     <>
                         <div className={styles.adjustInput} onClick={onWebSearchClicked}>
                             <Globe16Filled primaryFill="rgba(133, 133, 133, 1)" />

--- a/app/frontend/src/components/UserChatMessage/UserChatMessage.module.css
+++ b/app/frontend/src/components/UserChatMessage/UserChatMessage.module.css
@@ -9,6 +9,13 @@
     margin-left: auto;
 }
 
+.containerUngrounded {
+    display: flex;
+    margin-bottom: 20px;
+    max-width: 100%;
+    flex-direction: row;
+}
+
 .messagework {
     padding: 20px;
     background: linear-gradient(130deg, #2870EA 20%, #1B4AEF 77.5%);
@@ -33,6 +40,52 @@
     outline: transparent solid 1px;
 }
 
+.messageungrounded {
+    padding: 20px;
+    background: transparent;
+    outline: transparent;
+    display: flex;
+    flex-direction: column;
+}
+
+.messageungroundedheader {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    margin-bottom: 10px
+}
+
+.messageungroundedicon {
+    margin-right: '10px';
+    background-color: #d1dbfa;
+    color: #123bb6;
+    fill: #123bb6;
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 24px;
+    width: 24px;
+    border-radius: 50%;
+    font-size: 10px;
+    line-height: 14px;
+    font-weight: 600;
+    font-variation-settings: unset;
+}
+
+.messageungroundedtext {
+    padding-left: 10px;
+    font-size: 16px;
+    line-height: 22px;
+    font-weight: 700;
+    font-variation-settings: unset;
+}
+
 .userMessage {
     color: white;
+}
+
+.userMessageUngrounded {
+    color: rgba(0, 0, 0, 1);
+    padding-left: 36px;
 }

--- a/app/frontend/src/components/UserChatMessage/UserChatMessage.module.css
+++ b/app/frontend/src/components/UserChatMessage/UserChatMessage.module.css
@@ -9,10 +9,30 @@
     margin-left: auto;
 }
 
-.message {
+.messagework {
     padding: 20px;
-    background: #e8ebfa;
+    background: linear-gradient(130deg, #2870EA 20%, #1B4AEF 77.5%);
     border-radius: 8px;
     box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.14), 0px 0px 2px rgba(0, 0, 0, 0.12);
     outline: transparent solid 1px;
+}
+
+.messageweb {
+    padding: 20px;
+    background: linear-gradient(130deg, #39b468 20%, #188d45 77.5%);
+    border-radius: 8px;
+    box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.14), 0px 0px 2px rgba(0, 0, 0, 0.12);
+    outline: transparent solid 1px;
+}
+
+.messagecompare {
+    padding: 20px;
+    background: linear-gradient(130deg, #d68436 20%, #ce7b2e 77.5%);
+    border-radius: 8px;
+    box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.14), 0px 0px 2px rgba(0, 0, 0, 0.12);
+    outline: transparent solid 1px;
+}
+
+.userMessage {
+    color: white;
 }

--- a/app/frontend/src/components/UserChatMessage/UserChatMessage.tsx
+++ b/app/frontend/src/components/UserChatMessage/UserChatMessage.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import styles from "./UserChatMessage.module.css";
-import { GlobeSearch20Filled, DocumentSearch20Filled, Sparkle20Filled, Link16Filled } from "@fluentui/react-icons";
+import { GlobeSearch20Filled, BuildingMultiple20Filled, Person20Filled, Link16Filled } from "@fluentui/react-icons";
 import { Approaches } from "../../api";
 
 interface Props {
@@ -12,20 +12,20 @@ interface Props {
 
 export const UserChatMessage = ({ message, approach }: Props) => {
     return (
-        <div className={styles.container}>
-            <div className={approach == Approaches.ChatWebRetrieveRead ? styles.messageweb : approach == Approaches.ReadRetrieveRead ? styles.messagework : styles.messagecompare}>
+        <div className={approach == Approaches.GPTDirect ? styles.containerUngrounded : styles.container}>
+            <div className={approach == Approaches.ChatWebRetrieveRead ? styles.messageweb : approach == Approaches.ReadRetrieveRead ? styles.messagework : approach == Approaches.GPTDirect ? styles.messageungrounded : styles.messagecompare}>
                 {approach == Approaches.ReadRetrieveRead ? 
-                    <span style={{ marginRight: '10px' }}><DocumentSearch20Filled primaryFill={"rgba(255, 255, 225, 1)"}/></span> : 
+                    <span style={{ marginRight: '10px' }}><BuildingMultiple20Filled primaryFill={"rgba(255, 255, 225, 1)"}/></span> : 
                  approach == Approaches.ChatWebRetrieveRead ?   
                     <span style={{ marginRight: '10px' }}><GlobeSearch20Filled primaryFill={"rgba(255, 255, 225, 1)"}/></span> :
                 approach == Approaches.CompareWebWithWork ?
-                    <span style={{ marginRight: '10px' }}><GlobeSearch20Filled primaryFill={"rgba(255, 255, 225, 1)"}/><Link16Filled primaryFill={"rgba(255, 255, 225, 1)"}/><DocumentSearch20Filled primaryFill={"rgba(255, 255, 225, 1)"}/></span> :
+                    <span style={{ marginRight: '10px' }}><GlobeSearch20Filled primaryFill={"rgba(255, 255, 225, 1)"}/><Link16Filled primaryFill={"rgba(255, 255, 225, 1)"}/><BuildingMultiple20Filled primaryFill={"rgba(255, 255, 225, 1)"}/></span> :
                 approach == Approaches.CompareWorkWithWeb ?
-                    <span style={{ marginRight: '10px' }}><DocumentSearch20Filled primaryFill={"rgba(255, 255, 225, 1)"}/><Link16Filled primaryFill={"rgba(255, 255, 225, 1)"}/><GlobeSearch20Filled primaryFill={"rgba(255, 255, 225, 1)"}/></span> : 
+                    <span style={{ marginRight: '10px' }}><BuildingMultiple20Filled primaryFill={"rgba(255, 255, 225, 1)"}/><Link16Filled primaryFill={"rgba(255, 255, 225, 1)"}/><GlobeSearch20Filled primaryFill={"rgba(255, 255, 225, 1)"}/></span> : 
                 //else
-                    <span style={{ marginRight: '10px' }}><Sparkle20Filled primaryFill={"rgba(255, 255, 225, 1)"}/></span>
+                    <div className={styles.messageungroundedheader}><div className={styles.messageungroundedicon}><Person20Filled primaryFill={"rgba(0, 0, 0, 0.35)"}/></div><span className={styles.messageungroundedtext}>You</span></div>
                 }
-                <span className={styles.userMessage}>{message}</span>
+                <span className={approach == Approaches.GPTDirect ? styles.userMessageUngrounded : styles.userMessage}>{message}</span>
             </div>
         </div>
     );

--- a/app/frontend/src/components/UserChatMessage/UserChatMessage.tsx
+++ b/app/frontend/src/components/UserChatMessage/UserChatMessage.tsx
@@ -1,20 +1,31 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { Icon } from '@fluentui/react';
 import styles from "./UserChatMessage.module.css";
+import { GlobeSearch20Filled, DocumentSearch20Filled, Sparkle20Filled, Link16Filled } from "@fluentui/react-icons";
+import { Approaches } from "../../api";
 
 interface Props {
     message: string;
-    iconName?: string;
+    approach: Approaches;
 }
 
-export const UserChatMessage = ({ message, iconName }: Props) => {
+export const UserChatMessage = ({ message, approach }: Props) => {
     return (
         <div className={styles.container}>
-            <div className={styles.message}>
-                {iconName && <span style={{ marginRight: '10px' }}><Icon iconName={iconName} /></span>}
-                <span>{message}</span>
+            <div className={approach == Approaches.ChatWebRetrieveRead ? styles.messageweb : approach == Approaches.ReadRetrieveRead ? styles.messagework : styles.messagecompare}>
+                {approach == Approaches.ReadRetrieveRead ? 
+                    <span style={{ marginRight: '10px' }}><DocumentSearch20Filled primaryFill={"rgba(255, 255, 225, 1)"}/></span> : 
+                 approach == Approaches.ChatWebRetrieveRead ?   
+                    <span style={{ marginRight: '10px' }}><GlobeSearch20Filled primaryFill={"rgba(255, 255, 225, 1)"}/></span> :
+                approach == Approaches.CompareWebWithWork ?
+                    <span style={{ marginRight: '10px' }}><GlobeSearch20Filled primaryFill={"rgba(255, 255, 225, 1)"}/><Link16Filled primaryFill={"rgba(255, 255, 225, 1)"}/><DocumentSearch20Filled primaryFill={"rgba(255, 255, 225, 1)"}/></span> :
+                approach == Approaches.CompareWorkWithWeb ?
+                    <span style={{ marginRight: '10px' }}><DocumentSearch20Filled primaryFill={"rgba(255, 255, 225, 1)"}/><Link16Filled primaryFill={"rgba(255, 255, 225, 1)"}/><GlobeSearch20Filled primaryFill={"rgba(255, 255, 225, 1)"}/></span> : 
+                //else
+                    <span style={{ marginRight: '10px' }}><Sparkle20Filled primaryFill={"rgba(255, 255, 225, 1)"}/></span>
+                }
+                <span className={styles.userMessage}>{message}</span>
             </div>
         </div>
     );

--- a/app/frontend/src/pages/chat/Chat.module.css
+++ b/app/frontend/src/pages/chat/Chat.module.css
@@ -8,6 +8,13 @@
     margin-top: 20px;
 }
 
+.subHeader {
+    display: flex;
+    flex-direction: row;
+    margin-bottom: 10px;
+    justify-content: space-between;
+}
+
 .chatRoot {
     flex: 1;
     display: flex;
@@ -31,9 +38,16 @@
     padding-top: 10px;
 }
 
+.chatEmptyStateHeader {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+}
+
 .chatEmptyStateTitle {
-    font-size: 4rem;
-    font-weight: 600;
+    font-size: 3rem;
+    font-weight: 500;
     margin-top: 0;
     margin-bottom: 10px;
 }
@@ -42,16 +56,16 @@
     padding-left: 160px;
     padding-right: 160px;
     text-align: center;
-    font-size: 14px;
+    font-size: 12px;
 }
 
 .chatEmptyObjectivesList {
     text-align: center;
-    font-size: 14px;
+    font-size: 12px;
     display: flex;
     flex-direction: row;
-    padding-bottom: 50px;
-    padding-top: 30px;
+    padding-bottom: 40px;
+    padding-top: 24px;
 }
 
 .chatEmptyObjectivesListItem {
@@ -62,8 +76,8 @@
 }
 
 .chatEmptyObjectivesListItemText {
-    padding-right: 10px;
-    padding-left: 10px;
+    padding-right: 6px;
+    padding-left: 6px;
 }
 
 .chatEmptyStateSubtitle {
@@ -147,4 +161,37 @@
 
 .hide {
     display: none;
+}
+
+.defaultApproachWebOption {
+    font-size: 18px;
+    font-weight: 600;
+    color: #188d45;
+    padding-right: 10px;
+}
+
+.defaultApproachWorkOption {
+    font-size: 18px;
+    font-weight: 600;
+    color: #1B4AEF;
+    padding-left: 10px;
+}
+
+.defaultApproachSwitch {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+}
+
+.chatInputWarningMessage{
+    font-size: 12px;
+    font-weight: 400;
+    color: rgb(133, 133, 133);
+    line-height: 22px;
+    padding-top: 6px;
+    padding-bottom: 6px;
+    white-space: pre-line;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
 }

--- a/app/frontend/src/pages/chat/Chat.tsx
+++ b/app/frontend/src/pages/chat/Chat.tsx
@@ -439,9 +439,7 @@ const Chat = () => {
                     <TextField className={styles.chatSettingsSeparator} defaultValue={userPersona} label="User Persona" onChange={onUserPersonaChange} />
                     <TextField className={styles.chatSettingsSeparator} defaultValue={systemPersona} label="System Persona" onChange={onSystemPersonaChange} />
                     <ResponseLengthButtonGroup className={styles.chatSettingsSeparator} onClick={onResponseLengthChange} defaultValue={responseLength} />
-                    {activeChatMode != ChatMode.Ungrounded &&
-                        <ResponseTempButtonGroup className={styles.chatSettingsSeparator} onClick={onResponseTempChange} defaultValue={responseTemp} />
-                    }
+                    <ResponseTempButtonGroup className={styles.chatSettingsSeparator} onClick={onResponseTempChange} defaultValue={responseTemp} />
                     {activeChatMode != ChatMode.Ungrounded &&
                         <div>
                             <Separator className={styles.chatSettingsSeparator}>Filter Search Results by</Separator>

--- a/app/frontend/src/pages/layout/Layout.module.css
+++ b/app/frontend/src/pages/layout/Layout.module.css
@@ -81,17 +81,6 @@
     height: 20px;
 }
 
-.raibanner {
-    display: grid;
-    grid-template-columns: 1fr 2fr 1fr;
-    align-items: center;
-    background-color: rgb(242, 242, 242);
-    height: fit-content;
-    -webkit-box-shadow: 2px 2px 2px 0 rgba(0,0,0,0.3) ;
-    box-shadow: 2px 2px 2px 0 rgba(0,0,0,0.3) ;
-    opacity: 25.0;
-}
-
 .centered {
     display: flex;
     justify-content: center;
@@ -101,15 +90,3 @@
     display: flex;
     justify-content: center;
 }
-
-.raiwarning {
-    font-size: 12px;
-    font-weight: 400;
-    color: rgb(133, 133, 133);
-    line-height: 22px;
-    padding-top: 6px;
-    padding-bottom: 6px;
-    white-space: pre-line;
-}
-
-

--- a/app/frontend/src/pages/layout/Layout.tsx
+++ b/app/frontend/src/pages/layout/Layout.tsx
@@ -12,16 +12,6 @@ import React from "react";
 import Switch from 'react-switch';
 
 const Layout = () => {
-    // const { toggle, setToggle } = React.useContext(ToggleContext);
-
-    // const handleToggle = () => {
-    //     setToggle(prevToggle => prevToggle === 'Work' ? 'Web' : 'Work');
-    // };
-    const { toggle, setToggle } = React.useContext(ToggleContext);
-
-    const handleToggle = () => {
-        setToggle((prevToggle) => (prevToggle === 'Work' ? 'Web' : 'Work'));
-    };
         return (
             <div className={styles.layout}>
                 <header className={styles.header} role={"banner"}>
@@ -47,25 +37,6 @@ const Layout = () => {
                         </nav>
                     </div>
                 </header>
-                <div className={styles.raibanner}>
-                    <div></div>
-                    <div className={styles.centered}>
-                        <span className={styles.raiwarning}>AI-generated content may be incorrect</span>
-                    </div>
-                    <div className={styles.right}>
-                        <Switch
-                            onChange={handleToggle}
-                            checked={toggle === 'Web'}
-                            uncheckedIcon={false}
-                            checkedIcon={false}
-                            onColor="#86d3ff"
-                            offColor="#ccc"
-                        />
-                        <label onClick={handleToggle} style={{ marginLeft: '10px', cursor: 'pointer' }}>
-                            {toggle === 'Work' ? 'Switch to Web' : 'Switch to Work'}
-                        </label>
-                    </div>
-                </div>
 
                 <Outlet />
 

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -167,7 +167,7 @@ module "backend" {
     TARGET_EMBEDDINGS_MODEL                 = var.useAzureOpenAIEmbeddings ? "azure-openai_${var.azureOpenAIEmbeddingDeploymentName}" : var.sentenceTransformersModelName
     ENRICHMENT_APPSERVICE_URL               = module.enrichmentApp.uri
     ENRICHMENT_ENDPOINT                     = module.cognitiveServices.cognitiveServiceEndpoint
-    APPLICATION_TITLE                       = var.applicationtitle
+    APPLICATION_TITLE                       = var.applicationtitle == "" ? "Information Assistant, built with Azure OpenAI" : var.applicationtitle
     AZURE_AI_TRANSLATION_DOMAIN             = var.azure_ai_translation_domain
     USE_SEMANTIC_RERANKER                   = var.use_semantic_reranker
     BING_SEARCH_ENDPOINT                    = var.enableWebChat ? module.bingSearch[0].endpoint : ""


### PR DESCRIPTION
In this PR we have added 3 separate modes under the Chat UX. 

- Work Only: This limits the chat experience to only RAG based on data uploaded into Info Asst (the normal chat experience from before)
- Work + Web: This experience has a new feature that allows a user to get an answer based on data uploaded to IA, Bing search results, or compare and contrast the answers between Work and Web
- Generative (Ungounded): This experience lets the user interact with the LLM natively WITHOUT any grounded information. This IS NOT a RAG pattern. 