### PR TITLE
Refactor file retry functionality and update API endpoint

### DIFF
--- a/app/frontend/src/api/api.ts
+++ b/app/frontend/src/api/api.ts
@@ -231,24 +231,6 @@ export async function getTags(): Promise<string[]> {
 }
 
 
-export async function retryFile(filePath: string): Promise<boolean> {
-    const response = await fetch("/retryFile", {
-        method: "POST",
-        headers: {
-            "Content-Type": "application/json"
-        },
-        body: JSON.stringify({
-            filePath: filePath
-            })
-        });
-    
-    const parsedResponse: String = await response.json();
-    if (response.status > 299 || !response.ok) {
-        throw Error("Unknown error");
-    }
-
-    return true;
-}
 export async function getHint(question: string): Promise<String> {
     const response = await fetch(`/getHint?question=${encodeURIComponent(question)}`, {
         method: "GET",
@@ -264,6 +246,7 @@ export async function getHint(question: string): Promise<String> {
 
     return parsedResponse;
 }
+
 export async function getSolve(question: string): Promise<String[]> {
     const response = await fetch(`/getSolve?question=${encodeURIComponent(question)}`, {
         method: "GET",

--- a/app/frontend/src/components/FileStatus/DocumentsDetailList.tsx
+++ b/app/frontend/src/components/FileStatus/DocumentsDetailList.tsx
@@ -17,7 +17,6 @@ import { DetailsList,
     DefaultButton, 
     Panel,
     PanelType} from "@fluentui/react";
-import { retryFile } from "../../api";
 import styles from "./DocumentsDetailList.module.css";
 import { deleteItem, DeleteItemRequest, resubmitItem, ResubmitItemRequest } from "../../api";
 import { StatusContent } from "../StatusContent/StatusContent";
@@ -88,27 +87,6 @@ export const DocumentsDetailList = ({ items, onFilesSorted, onRefresh }: Props) 
     }
 
     const [itemList, setItems] = useState<IDocument[]>(items);
-    function retryErroredFile(item: IDocument): void {
-        retryFile(item.filePath)
-            .then(() => {
-                // Create a new array with the updated item
-                const updatedItems = itemList.map((i) => {
-                    if (i.key === item.key) {
-                        return {
-                            ...i,
-                            state: "Queued"
-                        };
-                    }
-                    return i;
-                });
-    
-                setItems(updatedItems); // Update the state with the new array
-                console.log("State updated, triggering re-render");
-            })
-            .catch((error) => {
-                console.error("Error retrying file:", error);
-            });
-    }
     
     // Initialize Selection with items
     useEffect(() => {
@@ -303,7 +281,6 @@ export const DocumentsDetailList = ({ items, onFilesSorted, onRefresh }: Props) 
                     <span onClick={() => onStateColumnClick(item)} style={{ cursor: 'pointer' }}>
                         {item.state}
                     </span>
-                    {item.state === 'Error' && <a href="javascript:void(0);" onClick={() => retryErroredFile(item)}> - Retry File</a>}
                 </TooltipHost>
             ), 
             isPadded: true,


### PR DESCRIPTION
This PR was to remove a redundant retry/resubmit function that was from an initial PR to manage this from the community. This was replaced by the new resubmit and delete function some time back. The PR addresses this, but during dev I discovered another error. When a file was resubmitted, its status was not changing immediately in the document status table. This was because a net new json document was being created for the file. The reason this was happening is because the document key is the encoded full path of the file including the container, 'upload'. On resubmission it was just using the file name, hence another document. I have added the full path and verified it works as expected now