### PR TITLE
Revert fix causing deployment issue

### DIFF
--- a/app/frontend/vite.config.ts
+++ b/app/frontend/vite.config.ts
@@ -8,10 +8,7 @@ export default defineConfig({
     build: {
         outDir: "../backend/static",
         emptyOutDir: true,
-        sourcemap: true,
-        rollupOptions: {
-            external: ['@azure/storage-blob']
-          }
+        sourcemap: true
     },
     server: {
         proxy: {


### PR DESCRIPTION
This was a change introduced as part of a 7032 fix.
However it causes this error on deployment.

Uncaught TypeError: Failed to resolve module specifier "@azure/storage-blob". Relative references must start with either "/", "./", or "../".

This is a quick PR to revert that change.