### PR TITLE
Fix work web citation context on compare

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -293,14 +293,15 @@ async def chat(request: Request):
             return {"error": "unknown approach"}, 400
         
         if (Approaches(int(approach)) == Approaches.CompareWorkWithWeb or Approaches(int(approach)) == Approaches.CompareWebWithWork):
-            r = await impl.run(json_body.get("history", []), json_body.get("overrides", {}), json_body.get("citation_lookup", {}))
+            r = await impl.run(json_body.get("history", []), json_body.get("overrides", {}), json_body.get("citation_lookup", {}), json_body.get("thought_chain", {}))
         else:
-            r = await impl.run(json_body.get("history", []), json_body.get("overrides", {}), {})
+            r = await impl.run(json_body.get("history", []), json_body.get("overrides", {}), {}, json_body.get("thought_chain", {}))
        
         response = {
                 "data_points": r["data_points"],
                 "answer": r["answer"],
                 "thoughts": r["thoughts"],
+                "thought_chain": r["thought_chain"],
                 "work_citation_lookup": r["work_citation_lookup"],
                 "web_citation_lookup": r["web_citation_lookup"]
         }

--- a/app/backend/approaches/approach.py
+++ b/app/backend/approaches/approach.py
@@ -25,13 +25,15 @@ class Approach:
     USER = "user"
     ASSISTANT = "assistant"
 
-    async def run(self, history: list[dict], overrides: dict) -> any:
+    async def run(self, history: list[dict], overrides: dict, citation_lookup: dict[str, Any], thought_chain: dict[str, Any]) -> any:
         """
         Run the approach on the query and documents. Not implemented.
 
         Args:
             history: The chat history. (e.g. [{"user": "hello", "bot": "hi"}])
             overrides: Overrides for the approach. (e.g. temperature, etc.)
+            citation_lookup: The dictionary for the citations.
+            thought_chain: The dictionary for the thought chain.
         """
         raise NotImplementedError
 

--- a/app/backend/approaches/comparewebwithwork.py
+++ b/app/backend/approaches/comparewebwithwork.py
@@ -38,8 +38,6 @@ class CompareWebWithWork(Approach):
         {'role': Approach.ASSISTANT, 'content': "User emphasizes the importance of comparing and contrasting data even if one of the sources is uncertain about the answer."}
     ]
     
-    work_citations = {}
-
     def __init__(
         self,
         search_client: SearchClient,
@@ -85,7 +83,7 @@ class CompareWebWithWork(Approach):
         self.azure_ai_translation_domain = azure_ai_translation_domain
         self.use_semantic_reranker = use_semantic_reranker
 
-    async def run(self, history: Sequence[dict[str, str]], overrides: dict[str, Any], web_citation_lookup: dict[str, Any]) -> Any:
+    async def run(self, history: Sequence[dict[str, str]], overrides: dict[str, Any], web_citation_lookup: dict[str, Any], thought_chain: dict[str, Any]) -> Any:
         """
         Runs the approach to compare and contrast answers from internal data and Web Search results.
 
@@ -118,10 +116,10 @@ class CompareWebWithWork(Approach):
                                     self.azure_ai_translation_domain,
                                     self.use_semantic_reranker
                                 )
-        rrr_response = await chat_rrr_approach.run(history, overrides, {})
+        rrr_response = await chat_rrr_approach.run(history, overrides, {}, thought_chain)
         
 
-        self.work_citations = rrr_response.get("work_citation_lookup")
+        work_citations = rrr_response.get("work_citation_lookup")
         user_query = history[-1].get("user")
         web_answer = next((obj['bot'] for obj in reversed(history) if 'bot' in obj), None)
         user_persona = overrides.get("user_persona", "")
@@ -130,7 +128,7 @@ class CompareWebWithWork(Approach):
 
         # Step 2: Contruct the comparative system message with passed Rag response and Bing Search Response from above approach
         bing_compare_query = user_query + " Web search results:\n" + web_answer + "\n\n" + "Work internal Documents:\n" + rrr_response.get("answer") + "\n\n"
-
+        thought_chain["web_to_work_comparison_query"] = bing_compare_query
         messages = self.get_messages_builder(
             self.COMPARATIVE_SYSTEM_MESSAGE_CHAT_CONVERSATION.format(
                 query_term_language=self.query_term_language,
@@ -154,15 +152,16 @@ class CompareWebWithWork(Approach):
         final_response = f"{urllib.parse.unquote(bing_compare_resp)}"
 
         # Step 4: Append web citations from the Bing Search approach
-        for idx, url in enumerate(self.work_citations.keys(), start=1):
+        for idx, url in enumerate(work_citations.keys(), start=1):
             final_response += f" [File{idx}]"
-
+        thought_chain["web_to_work_comparison_response"] = final_response
         
         return {
             "data_points": None,
             "answer": f"{urllib.parse.unquote(final_response)}",
             "thoughts": "Searched for:<br>A Comparitive Analysis<br><br>Conversations:<br>" + msg_to_display.replace('\n', '<br>'),
-            "work_citation_lookup": self.work_citations,
+            "thought_chain": thought_chain,
+            "work_citation_lookup": work_citations,
             "web_citation_lookup": web_citation_lookup
         }
     

--- a/app/backend/approaches/compareworkwithweb.py
+++ b/app/backend/approaches/compareworkwithweb.py
@@ -56,7 +56,7 @@ class CompareWorkWithWeb(Approach):
         self.bing_search_key = bing_search_key
         self.bing_safe_search = bing_safe_search
 
-    async def run(self, history: Sequence[dict[str, str]], overrides: dict[str, Any], work_citation_lookup: dict[str, Any]) -> Any:
+    async def run(self, history: Sequence[dict[str, str]], overrides: dict[str, Any], work_citation_lookup: dict[str, Any], thought_chain: dict[str, Any]) -> Any:
         """
         Runs the comparative analysis between Bing Search Response and Internal Documents.
 
@@ -69,7 +69,7 @@ class CompareWorkWithWeb(Approach):
         """
         # Step 1: Call bing Search Approach for a Bing LLM Response and Citations
         chat_bing_search = ChatWebRetrieveRead(self.model_name, self.chatgpt_deployment, self.query_term_language, self.bing_search_endpoint, self.bing_search_key, self.bing_safe_search)
-        bing_search_response = await chat_bing_search.run(history, overrides, {})
+        bing_search_response = await chat_bing_search.run(history, overrides, {}, thought_chain)
         self.web_citations = bing_search_response.get("web_citation_lookup")
 
         user_query = history[-1].get("user")
@@ -80,8 +80,7 @@ class CompareWorkWithWeb(Approach):
 
         # Step 2: Contruct the comparative system message with passed Rag response and Bing Search Response from above approach
         bing_compare_query = user_query + "Work internal documents:\n" + rag_answer + "\n\n" + " Web search results:\n" + bing_search_response.get("answer") + "\n\n"
-        
-
+        thought_chain["work_to_web_compairison_query"] = bing_compare_query
         messages = self.get_messages_builder(
             self.COMPARATIVE_SYSTEM_MESSAGE_CHAT_CONVERSATION.format(
                 query_term_language=self.query_term_language,
@@ -107,11 +106,13 @@ class CompareWorkWithWeb(Approach):
         # Step 4: Append web citations from the Bing Search approach
         for idx, url in enumerate(self.web_citations.keys(), start=1):
             final_response += f" [url{idx}]"
-
+        thought_chain["work_to_web_compairison_response"] = final_response
+        
         return {
             "data_points": None,
             "answer": f"{urllib.parse.unquote(final_response)}",
             "thoughts": "Searched for:<br>A Comparitive Analysis<br><br>Conversations:<br>" + msg_to_display.replace('\n', '<br>'),
+            "thought_chain": thought_chain,
             "work_citation_lookup": work_citation_lookup,
             "web_citation_lookup": self.web_citations
         }

--- a/app/backend/approaches/gpt_direct_approach.py
+++ b/app/backend/approaches/gpt_direct_approach.py
@@ -94,13 +94,13 @@ class GPTDirectApproach(Approach):
         self.model_version = model_version
 
     # def run(self, history: list[dict], overrides: dict) -> any:
-    async def run(self, history: Sequence[dict[str, str]], overrides: dict[str, Any], citation_lookup: dict[str, Any]) -> Any:
+    async def run(self, history: Sequence[dict[str, str]], overrides: dict[str, Any], citation_lookup: dict[str, Any], thought_chain: dict[str, Any]) -> Any:
         user_persona = overrides.get("user_persona", "")
         system_persona = overrides.get("system_persona", "")
         response_length = int(overrides.get("response_length") or 1024)
 
         user_q = 'Generate response for: ' + history[-1]["user"]
-
+        thought_chain["user_query"] = history[-1]["user"]
         #Generate the follow up prompt to be sent to the GPT model
         follow_up_questions_prompt = (
             self.follow_up_questions_prompt_content
@@ -139,11 +139,13 @@ class GPTDirectApproach(Approach):
 
         #Format the response
         msg_to_display = '\n\n'.join([str(message) for message in messages])
+        thought_chain["ungrounded_response"] = urllib.parse.unquote(chat_completion.choices[0].message.content)
 
         return {
             "data_points": [],
             "answer": f"{urllib.parse.unquote(chat_completion.choices[0].message.content)}",
             "thoughts": f"Searched for:<br>{user_q}<br><br>Conversations:<br>" + msg_to_display.replace('\n', '<br>'),
+            "thought_chain": thought_chain,
             "work_citation_lookup": {},
             "web_citation_lookup": {}
         }

--- a/app/frontend/src/api/api.ts
+++ b/app/frontend/src/api/api.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { AskResponse, 
+import { ChatResponse, 
     ChatRequest, 
     BlobClientUrlResponse, 
     AllFilesUploadStatus, 
@@ -18,7 +18,7 @@ import { AskResponse,
     GetFeatureFlagsResponse,
     } from "./models";
 
-export async function chatApi(options: ChatRequest): Promise<AskResponse> {
+export async function chatApi(options: ChatRequest): Promise<ChatResponse> {
     const response = await fetch("/chat", {
         method: "POST",
         headers: {
@@ -46,11 +46,12 @@ export async function chatApi(options: ChatRequest): Promise<AskResponse> {
                 selected_folders: options.overrides?.selectedFolders,
                 selected_tags: options.overrides?.selectedTags
             },
-            citation_lookup: options.citation_lookup
+            citation_lookup: options.citation_lookup,
+            thought_chain: options.thought_chain
         })
     });
 
-    const parsedResponse: AskResponse = await response.json();
+    const parsedResponse: ChatResponse = await response.json();
     if (response.status > 299 || !response.ok) {
         throw Error(parsedResponse.error || "Unknown error");
     }

--- a/app/frontend/src/api/models.ts
+++ b/app/frontend/src/api/models.ts
@@ -17,7 +17,7 @@ export const enum Approaches {
     CompareWebWithWork = 6
 }
 
-export type AskRequestOverrides = {
+export type ChatRequestOverrides = {
     semanticRanker?: boolean;
     semanticCaptions?: boolean;
     excludeCategory?: string;
@@ -37,11 +37,12 @@ export type AskRequestOverrides = {
     selectedTags?: string;
 };
 
-export type AskResponse = {
+export type ChatResponse = {
     answer: string;
     thoughts: string | null;
     data_points: string[];
     approach: Approaches;
+    thought_chain: { [key: string]: string };
     work_citation_lookup: { [key: string]: { citation: string; source_path: string; page_number: string } };
     web_citation_lookup: { [key: string]: { citation: string; source_path: string; page_number: string } };
     error?: string;
@@ -61,8 +62,9 @@ export type Citation = {
 export type ChatRequest = {
     history: ChatTurn[];
     approach: Approaches;
-    overrides?: AskRequestOverrides;
+    overrides?: ChatRequestOverrides;
     citation_lookup: { [key: string]: { citation: string; source_path: string; page_number: string } };
+    thought_chain: { [key: string]: string };
 };
 
 export type BlobClientUrlResponse = {

--- a/app/frontend/src/components/AnalysisPanel/AnalysisPanel.tsx
+++ b/app/frontend/src/components/AnalysisPanel/AnalysisPanel.tsx
@@ -12,7 +12,7 @@ import remarkGfm from 'remark-gfm'
 import styles from "./AnalysisPanel.module.css";
 
 import { SupportingContent } from "../SupportingContent";
-import { AskResponse, ActiveCitation, getCitationObj } from "../../api";
+import { ChatResponse, ActiveCitation, getCitationObj } from "../../api";
 import { AnalysisPanelTabs } from "./AnalysisPanelTabs";
 
 interface Props {
@@ -23,7 +23,7 @@ interface Props {
     sourceFile: string | undefined;
     pageNumber: string | undefined;
     citationHeight: string;
-    answer: AskResponse;
+    answer: ChatResponse;
 }
 
 const pivotItemDisabledStyle = { disabled: true, style: { color: "grey" } };

--- a/app/frontend/src/components/Answer/Answer.tsx
+++ b/app/frontend/src/components/Answer/Answer.tsx
@@ -8,13 +8,13 @@ import DOMPurify from "dompurify";
 
 import styles from "./Answer.module.css";
 
-import { Approaches, AskResponse, getCitationFilePath, ChatMode } from "../../api";
+import { Approaches, ChatResponse, getCitationFilePath, ChatMode } from "../../api";
 import { parseAnswerToHtml } from "./AnswerParser";
 import { AnswerIcon } from "./AnswerIcon";
 import { RAIPanel } from "../RAIPanel";
 
 interface Props {
-    answer: AskResponse;
+    answer: ChatResponse;
     isSelected?: boolean;
     onCitationClicked: (filePath: string, sourcePath: string, pageNumber: string) => void;
     onThoughtProcessClicked: () => void;
@@ -46,7 +46,7 @@ export const Answer = ({
     onRegenerateClick,
     chatMode
 }: Props) => {
-    const parsedAnswer = useMemo(() => parseAnswerToHtml(answer.answer, answer.approach, answer.work_citation_lookup, answer.web_citation_lookup, onCitationClicked), [answer]);
+    const parsedAnswer = useMemo(() => parseAnswerToHtml(answer.answer, answer.approach, answer.work_citation_lookup, answer.web_citation_lookup, answer.thought_chain, onCitationClicked), [answer]);
 
     const sanitizedAnswerHtml = DOMPurify.sanitize(parsedAnswer.answerHtml);
 
@@ -126,7 +126,7 @@ export const Answer = ({
                     </Stack>
                 </Stack.Item>
             )}
-            {(parsedAnswer.approach == Approaches.CompareWebWithWork && !!parsedAnswer.work_citations.length) && (
+            {parsedAnswer.approach == Approaches.CompareWebWithWork && (
                 <div>
                     <Stack.Item>
                         <Stack horizontal wrap tokens={{ childrenGap: 5 }}>
@@ -159,7 +159,7 @@ export const Answer = ({
                     </Stack.Item>
                 </div>
             )}
-            {(parsedAnswer.approach == Approaches.CompareWorkWithWeb && !!parsedAnswer.work_citations.length) && (
+            {parsedAnswer.approach == Approaches.CompareWorkWithWeb && (
                 <div>
                     <Stack.Item>
                         <Stack horizontal wrap tokens={{ childrenGap: 5 }}>

--- a/app/frontend/src/components/Answer/AnswerParser.tsx
+++ b/app/frontend/src/components/Answer/AnswerParser.tsx
@@ -17,13 +17,15 @@ type HtmlParsedAnswer = {
     approach: Approaches;
 };
 
+type ThoughtChain = Record<string, string>;
+
 type CitationLookup = Record<string, {
     citation: string;
     source_path: string;
     page_number: string;
 }>;
 
-export function parseAnswerToHtml(answer: string, approach: Approaches, work_citation_lookup: CitationLookup, web_citation_lookup: CitationLookup, onCitationClicked: (citationFilePath: string, citationSourcePath: string, pageNumber: string) => void): HtmlParsedAnswer {
+export function parseAnswerToHtml(answer: string, approach: Approaches, work_citation_lookup: CitationLookup, web_citation_lookup: CitationLookup, thought_chain: ThoughtChain, onCitationClicked: (citationFilePath: string, citationSourcePath: string, pageNumber: string) => void): HtmlParsedAnswer {
     const work_citations: string[] = [];
     const web_citations: string[] = [];
     const work_sourceFiles: Record<string, string> = {};
@@ -40,6 +42,9 @@ export function parseAnswerToHtml(answer: string, approach: Approaches, work_cit
     // trim any whitespace from the end of the answer after removing follow-up questions
     parsedAnswer = parsedAnswer.trim();
     var fragments: string[] = [];
+    var work_fragments: string[] = [];
+    var web_fragments: string[] = [];
+
     if (approach == Approaches.ChatWebRetrieveRead || approach == Approaches.ReadRetrieveRead) {
         // Split the answer into parts, where the odd parts are citations
         const parts = parsedAnswer.split(/\[([^\]]+)\]/g);
@@ -151,24 +156,64 @@ export function parseAnswerToHtml(answer: string, approach: Approaches, work_cit
                 return "";
             }
         });
-        // Enumerate over work_citation_lookup and add the property citation to work_citations string array
-        for (const key in work_citation_lookup) {
-            if (work_citation_lookup.hasOwnProperty(key)) {
-                const work_citation = work_citation_lookup[key].citation;
-                work_citations.push(work_citation.split("/").slice(4).join("/"));
-                work_sourceFiles[work_citation.split("/").slice(4).join("/")] = work_citation_lookup[key].source_path;
-                pageNumbers[work_citation] = Number(work_citation_lookup[key].page_number);
+        const work_parts = thought_chain["work_response"].split(/\[([^\]]+)\]/g);
+        work_fragments = work_parts.map((part, index) => {
+            // Enumerate over work_citation_lookup and add the property citation to work_citations string array
+            if (index % 2 === 0) {
+                // Even parts are just text
+                return part;
+            } else {
+                // LLM Sometimes refers to citations as "source"
+                part = part.replace("source", "File");
+                const work_citation = work_citation_lookup[part];
+                if (!work_citation) {
+                    // if the citation reference provided by the OpenAI response does not match a key in the citation_lookup object
+                    // then return an empty string to avoid a crash or blank citation
+                    console.log("citation not found for: " + part)
+                    return "";
+                }
+                else {
+                    // Check if the citation is already in the citations array
+                    if (work_citations.includes(work_citation.citation.split("/").slice(4).join("/"))) {
+                        // If it exists, don't add it again
+                    } else {
+                        work_citations.push(work_citation.citation.split("/").slice(4).join("/"));
+                        work_sourceFiles[work_citation.citation.split("/").slice(4).join("/")] = work_citation.source_path;
+                        pageNumbers[work_citation.citation] = Number(work_citation.page_number);
+                    }
+                }
             }
-        }
-        // Enumerate over web_citation_lookup and add the property citation to web_citations string array
-        for (const key in web_citation_lookup) {
-            if (web_citation_lookup.hasOwnProperty(key)) {
-                const web_citation = web_citation_lookup[key].citation;
-                web_citations.push(web_citation);
-                web_sourceFiles[web_citation] = web_citation_lookup[key].source_path;
-                pageNumbers[web_citation] = NaN;
+            return "";
+        });
+        const web_parts = thought_chain["web_response"].split(/\[([^\]]+)\]/g);
+        web_fragments = web_parts.map((part, index) => {
+            // Enumerate over web_citation_lookup and add the property citation to web_citations string array
+            if (index % 2 === 0) {
+                // Even parts are just text
+                return part;
+            } else {
+                // LLM Sometimes refers to citations as "source"
+                part = part.replace("source", "url");
+                const web_citation = web_citation_lookup[part];
+                if (!web_citation) {
+                    // if the citation reference provided by the OpenAI response does not match a key in the citation_lookup object
+                    // then return an empty string to avoid a crash or blank citation
+                    console.log("citation not found for: " + part)
+                    return "";
+                }
+                else {
+                    // Check if the citation is already in the citations array
+                    if (web_citations.includes(web_citation.citation)) {
+                        // If it exists, don't add it again
+                    } else {
+                        web_citations.push(web_citation.citation);
+                        web_sourceFiles[web_citation.citation] = web_citation.source_path;
+                        pageNumbers[web_citation.citation] = NaN;
+                    }
+                }
             }
-        }
+            return "";
+        });
     }
     if (approach == Approaches.GPTDirect) {
         fragments.push(parsedAnswer);


### PR DESCRIPTION
This PR fixes an issue where the context of which source content was actually cited in an answer from the LLM was lost. Since the focus in "Compare with Web" or "Compare with Work" is on the summarized answer on top of both the original work and web answers the code needed to be updated to maintain the chain of thought of those original answer to be able to identify which source content items were actually cited by the LLM responses. 

Fixes [AB#7369](https://dev.azure.com/pubsecsolutions/7c455e30-17db-4e93-aa6d-9b16ede5b431/_workitems/edit/7369)
Fixes [AB#7371](https://dev.azure.com/pubsecsolutions/7c455e30-17db-4e93-aa6d-9b16ede5b431/_workitems/edit/7371)