### PR TITLE
Geearl/7427 backoff error

### DIFF
--- a/functions/TextEnrichment/__init__.py
+++ b/functions/TextEnrichment/__init__.py
@@ -274,7 +274,7 @@ def trim_content(sentence, n):
 
 
 def requeue(response, message_json):
-    '''This function handles requeing and erroring of cognitive servcies'''
+    '''This function handles requeuing and erroring of cognitive services'''
     blob_path = message_json["blob_name"]
     queued_count = message_json["text_enrichment_queued_count"]
     if response.status_code == 429:

--- a/functions/TextEnrichment/__init__.py
+++ b/functions/TextEnrichment/__init__.py
@@ -33,7 +33,7 @@ enrichmentKey =  os.environ["ENRICHMENT_KEY"]
 enrichmentEndpoint = os.environ["ENRICHMENT_ENDPOINT"] 
 targetTranslationLanguage = os.environ["TARGET_TRANSLATION_LANGUAGE"] 
 max_requeue_count = int(os.environ["MAX_ENRICHMENT_REQUEUE_COUNT"])
-backoff = int(os.environ["ENRICHMENT_BACKOFF"])
+enrichment_backoff = int(os.environ["ENRICHMENT_BACKOFF"])
 azure_blob_content_storage_container = os.environ["BLOB_STORAGE_ACCOUNT_OUTPUT_CONTAINER_NAME"]
 queueName = os.environ["EMBEDDINGS_QUEUE"]
 azure_ai_translation_domain = os.environ["AZURE_AI_TRANSLATION_DOMAIN"]
@@ -281,9 +281,9 @@ def requeue(response, message_json):
         # throttled, so requeue with random backoff seconds to mitigate throttling,
         # unless it has hit the max tries
         if queued_count < max_requeue_count:
-            max_seconds = backoff * (queued_count**2)
+            max_seconds = enrichment_backoff * (queued_count**2)
             backoff = random.randint(
-                backoff * queued_count, max_seconds
+                enrichment_backoff * queued_count, max_seconds
             )
             queued_count += 1
             message_json["text_enrichment_queued_count"] = queued_count


### PR DESCRIPTION
[AB#7420](https://dev.azure.com/pubsecsolutions/7c455e30-17db-4e93-aa6d-9b16ede5b431/_workitems/edit/7420)

This change fixes an error that occurs when a message sent to text enrichment is requeued, due to throttling for example. The code was this...

backoff = int(os.environ["ENRICHMENT_BACKOFF"])

def requeue(response, message_json):
    '''This function handles requeing and erroring of cognitive servcies'''
    blob_path = message_json["blob_name"]
    queued_count = message_json["text_enrichment_queued_count"]
    if response.status_code == 429:
        # throttled, so requeue with random backoff seconds to mitigate throttling,
        # unless it has hit the max tries
        if queued_count < max_requeue_count:
            max_seconds = backoff * (queued_count**2)
            backoff = random.randint(
                backoff * queued_count, max_seconds
            )

The issue being that the global var backoff is being changed within a function, which gives an error. The fix was to use a different var name downstream rather than the same var. This is the same pattern in other functions