### PR TITLE
Add/Remove class when entering/leaving Chat

### DIFF
--- a/app/frontend/src/pages/chat/Chat.module.css
+++ b/app/frontend/src/pages/chat/Chat.module.css
@@ -30,7 +30,7 @@
 
 }
 
-body {
+.chat-overflow-hidden-body {
     overflow: hidden;
 }
 

--- a/app/frontend/src/pages/chat/Chat.tsx
+++ b/app/frontend/src/pages/chat/Chat.tsx
@@ -290,6 +290,15 @@ const Chat = () => {
         setSelectedTags(selectedTags)
     }
 
+    useEffect(() => {
+        // Hide Scrollbar for this page
+        document.body.classList.add('chat-overflow-hidden-body');
+        // Do not apply to other pages
+        return () => {
+            document.body.classList.remove('chat-overflow-hidden-body');
+        };
+    }, []);
+
     return (
         <div className={styles.container}>
             <div className={styles.subHeader}>


### PR DESCRIPTION
body overflow hidden is being applied to all pages as this is an SPA, despite being just in chat.module.css

This code adds and removes the class when entering/exiting chat so that the body scrollbar is still visible on other pages.

[AB#7430](https://dev.azure.com/pubsecsolutions/7c455e30-17db-4e93-aa6d-9b16ede5b431/_workitems/edit/7430)