### PR TITLE
Update Azure credential scopes in app.py

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -165,7 +165,8 @@ model_version = ''
 openai_mgmt_client = CognitiveServicesManagementClient(
     credential=azure_credential,
     subscription_id=ENV["AZURE_SUBSCRIPTION_ID"],
-    base_url=ENV["AZURE_ARM_MANAGEMENT_API"])
+    base_url=ENV["AZURE_ARM_MANAGEMENT_API"],
+    credential_scopes=[ENV["AZURE_ARM_MANAGEMENT_API"] + "/.default"])
 
 deployment = openai_mgmt_client.deployments.get(
     resource_group_name=ENV["AZURE_OPENAI_RESOURCE_GROUP"],


### PR DESCRIPTION
This PR fixes an issue in gov cloud deployments. The scope was not supplied when creating an azure openai, and so was defaulting to commercial and failing