### PR TITLE
Fix error handling in FileDeletion function

### DIFF
--- a/infra/core/storage/storage-account.tf
+++ b/infra/core/storage/storage-account.tf
@@ -28,6 +28,11 @@ resource "azurerm_storage_account" "storage" {
         exposed_headers = ["*"]
         max_age_in_seconds = 86400
         }
+      
+    delete_retention_policy {
+      days = 1
+      }
+        
     }
 }
 


### PR DESCRIPTION
This PR does 2 things:

1. If an error is encountered deleting a blob, all subsequent blobs are left. This catches exceptions at the blob level now and continues to the next one.
2. For some reason the storage container had soft delete disabled, which is required for the delete function to work. This has been added with a retention period of 1 day