### PR TITLE
chore: Add check for empty object_id before adding to array

### DIFF
--- a/infra/core/aad/entra.tf
+++ b/infra/core/aad/entra.tf
@@ -1,7 +1,7 @@
 data "azurerm_client_config" "current" {}
 
 locals {
-  principal_list = split(",", var.entraOwners)
+  principal_list = var.entraOwners == "" ? [] : split(",", var.entraOwners)
   owner_ids = contains(local.principal_list, data.azurerm_client_config.current.object_id) ? local.principal_list : concat(local.principal_list, [data.azurerm_client_config.current.object_id])
 }
 


### PR DESCRIPTION
When the additional Entra owners were set to "", there would be an error generated in TF as it couldn't assign to the array. Added a check for empty string and replaced with blank array. 