### PR TITLE
fix long running az cli command

### DIFF
--- a/scripts/inf-manual-destroy.sh
+++ b/scripts/inf-manual-destroy.sh
@@ -89,7 +89,7 @@ echo "Random text: $random_text"
 
 #delete ao_ai connection
 echo "Deleting open ai connection..."
-appid=$(az ad sp list --all --query "[?displayName=='infoasst-web-$random_text'].appId" -o tsv)
+appid=$(az ad sp list --filter "displayname eq 'infoasst-web-$random_text'" --output json | jq -r '.[].appId')
 echo "Deleting role assignment for app id: $appid"
 role_assignment_id=$(az role assignment list --resource-group $oa_ai_rg_name --query "[?principalName=='$appid'].id" -o tsv)
 echo "Role assignment id: $role_assignment_id"


### PR DESCRIPTION
This pull request includes a change to the `scripts/inf-manual-destroy.sh` file. The change modifies the command used to retrieve the `appid` value. Previously, the `az ad sp list --all` command was used with a query to filter the results. The updated code uses the `az ad sp list --filter` command instead, which directly filters the results based on the `displayname` value. The output is then parsed using `jq` to extract the `appId`. This change enhances the efficiency of the script by directly filtering the required data.