### PR TITLE
added VM

### DIFF
--- a/infra/core/vm.bicep
+++ b/infra/core/vm.bicep
@@ -1,0 +1,97 @@
+
+param vnetName string
+param subnetName string
+param vmName string
+param adminUsername string
+param adminPassword string
+
+resource vnet 'Microsoft.Network/virtualNetworks@2021-02-01' = {
+  name: vnetName
+  location: resourceGroup().location
+  properties: {
+    addressSpace: {
+      addressPrefixes: [
+        '10.0.0.0/16'
+      ]
+    }
+    subnets: [
+      {
+        name: subnetName
+        properties: {
+          addressPrefix: '10.0.0.0/24'
+        }
+      }
+    ]
+  }
+}
+
+resource publicIP 'Microsoft.Network/publicIPAddresses@2021-02-01' = {
+  name: '${vmName}-publicip'
+  location: resourceGroup().location
+  properties: {
+    publicIPAllocationMethod: 'None'
+  }
+}
+
+resource nic 'Microsoft.Network/networkInterfaces@2021-02-01' = {
+  name: '${vmName}-nic'
+  location: resourceGroup().location
+  properties: {
+    ipConfigurations: [
+      {
+        name: 'ipconfig'
+        properties: {
+          subnet: {
+            id: vnet.subnets[0].id
+          }
+          privateIPAllocationMethod: 'Dynamic'
+          publicIPAddress: {
+            id: publicIP.id
+          }
+        }
+      }
+    ]
+  }
+}
+
+resource vm 'Microsoft.Compute/virtualMachines@2021-03-01' = {
+  name: vmName
+  location: resourceGroup().location
+  dependsOn: [
+    nic
+  ]
+  properties: {
+    hardwareProfile: {
+      vmSize: 'Standard_DS2_v2'
+    }
+    osProfile: {
+      computerName: vmName
+      adminUsername: adminUsername
+      adminPassword: adminPassword
+      linuxConfiguration: {
+        disablePasswordAuthentication: false
+      }
+    }
+    storageProfile: {
+      imageReference: {
+        publisher: 'Canonical'
+        offer: 'UbuntuServer'
+        sku: '20.04-LTS'
+        version: 'latest'
+      }
+      osDisk: {
+        createOption: 'FromImage'
+        managedDisk: {
+          storageAccountType: 'Standard_LRS'
+        }
+      }
+    }
+    networkProfile: {
+      networkInterfaces: [
+        {
+          id: nic.id
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This pull request primarily involves changes to the `infra/core/vm.bicep` file. The changes are focused on the configuration of virtual machines (VMs) and their associated network settings. 

Key changes include:

* Added parameters for virtual network (`vnetName`), subnet (`subnetName`), VM (`vmName`), and admin credentials (`adminUsername`, `adminPassword`). This allows for greater flexibility in VM setup.

* Defined a new `vnet` resource with a specified address space and subnet. This change allows for more control over the network settings for the VMs.

* Added a public IP address resource (`publicIP`) with no allocation method specified. This suggests that the VMs will not have a public IP address by default.

* Defined a new network interface (`nic`) that connects to the `vnet` and `publicIP` resources. This is crucial for establishing network connectivity for the VMs.

* Created a new VM resource (`vm`) with specified hardware profile, OS profile, storage profile, and network profile. This provides a comprehensive setup for the VMs, including their hardware specifications, operating system, storage options, and network interfaces. 

In summary, these changes provide a more detailed and flexible setup for creating VMs and their associated network settings in the `infra/core/vm.bicep` file.