### PR TITLE
chore: Update deployment configuration link in features documentation

### DIFF
--- a/docs/features/features.md
+++ b/docs/features/features.md
@@ -59,7 +59,7 @@ The Information Assistant Accelerator [pre-processes](/docs/features/document_pr
 
 We also log the status of the pre-processing in Azure Cosmos DB. View our [Status Logging](/functions/shared_code/status_log.md) page for more details.
 
-Additionally, there are many configuration values that can be altered to effect the performance and behaviors of the chunking patterns. More details on the deployment configurations can be found in our [Function Flow documentation](/docs/functions_flow.md)
+Additionally, there are many configuration values that can be altered to effect the performance and behaviors of the chunking patterns. More details on the deployment configurations can be found in our [Function Flow documentation](/docs/features/document_pre_processing.md)
 
 ## SharePoint Connector
 


### PR DESCRIPTION
simple fix to a broken link in the docs