### PR TITLE
Update function managed identity to have right Search role

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -773,18 +773,18 @@ module "webApp_SearchIndexDataReader" {
   resourceGroupId  = azurerm_resource_group.rg.id
 }
 
-module "functionApp_SearchIndexDataReader" {
+module "functionApp_SearchIndexDataContributor" {
   source = "./core/security/role"
 
   scope            = azurerm_resource_group.rg.id
   principalId      = module.functions.identityPrincipalId
-  roleDefinitionId = local.azure_roles.SearchIndexDataReader
+  roleDefinitionId = local.azure_roles.SearchIndexDataContributor
   principalType    = "ServicePrincipal"
   subscriptionId   = data.azurerm_client_config.current.subscription_id
   resourceGroupId  = azurerm_resource_group.rg.id
 }
 
-module "encrichmentApp_SearchIndexDataReader" {
+module "encrichmentApp_SearchIndexDataContributor" {
   source = "./core/security/role"
 
   scope            = azurerm_resource_group.rg.id


### PR DESCRIPTION
This pull request includes changes to update the role assignments in the `infra/main.tf` file. The primary change involves renaming and updating the role definitions for several modules to use the `SearchIndexDataContributor` role instead of the `SearchIndexDataReader` role.

Role assignment updates:

* [`infra/main.tf`](diffhunk://#diff-c4edee4039d22cfe2fd0d1ef214e7eba022aa85b29dd5677f4485f60e5b7a668L776-R787): Renamed `module "functionApp_SearchIndexDataReader"` to `module "functionApp_SearchIndexDataContributor"` and updated the `roleDefinitionId` to `local.azure_roles.SearchIndexDataContributor`.
* [`infra/main.tf`](diffhunk://#diff-c4edee4039d22cfe2fd0d1ef214e7eba022aa85b29dd5677f4485f60e5b7a668L776-R787): Renamed `module "encrichmentApp_SearchIndexDataReader"` to `module "encrichmentApp_SearchIndexDataContributor"` and updated the `roleDefinitionId` to `local.azure_roles.SearchIndexDataContributor`.