### PR TITLE
fix the url encoding when generating sas tokens for citations

### DIFF
--- a/app/backend/approaches/chatreadretrieveread.py
+++ b/app/backend/approaches/chatreadretrieveread.py
@@ -310,7 +310,7 @@ class ChatReadRetrieveReadApproach(Approach):
             # add the "FileX" moniker and full file name to the citation lookup
             citation_lookup[f"File{idx}"] = {
                 "citation": urllib.parse.unquote("https://" + doc[self.source_file_field].split("/")[2] + f"/{self.content_storage_container}/" + doc[self.chunk_file_field]),
-                "source_path": self.get_source_file_with_sas(doc[self.source_file_field]),
+                "source_path": self.get_source_file_with_sas(urllib.parse.unquote(doc[self.source_file_field])),
                 "page_number": str(doc[self.page_number_field][0]) or "0",
              }
             


### PR DESCRIPTION
This pull request includes a small but important change to the `run` method in the `chatreadretrieveread.py` file. The change involves modifying how the `source_path` is processed to ensure it is correctly unquoted.

* [`app/backend/approaches/chatreadretrieveread.py`](diffhunk://#diff-a346ba4129613c27f42a9a4de5439423af8ab6df6eb79eaf555204da3d588001L313-R313): Modified the `source_path` assignment in the `run` method to use `urllib.parse.unquote` on the `doc[self.source_file_field]` to ensure the source path is correctly decoded.