### PR TITLE
Bump nltk from 3.8.1 to 3.9 in /functions

### DIFF
--- a/functions/requirements.txt
+++ b/functions/requirements.txt
@@ -12,7 +12,7 @@ azure-core == 1.30.2
 lxml == 4.9.2
 azure-cosmos == 4.7.0
 azure-storage-queue == 12.6.0
-nltk == 3.8.1
+nltk == 3.9
 tenacity == 8.2.3
 unstructured[csv,doc,docx,email,html,md,msg,ppt,pptx,text,xlsx,xml] == 0.12.5
 pyoo == 1.4

--- a/scripts/environments/usgov-ia.env
+++ b/scripts/environments/usgov-ia.env
@@ -1,6 +1,6 @@
 # Region to deploy into when running locally.
 # This is set by the Azure Pipeline for other environments.
-export LOCATION="usgovvirginia"
+export LOCATION="usgovarizona"
 export WORKSPACE="tmp_gov$BUILD_BUILDID"
 export SUBSCRIPTION_ID="$ARM_SUBSCRIPTION_ID"
 

--- a/scripts/environments/usgov-ia.env
+++ b/scripts/environments/usgov-ia.env
@@ -1,6 +1,6 @@
 # Region to deploy into when running locally.
 # This is set by the Azure Pipeline for other environments.
-export LOCATION="usgovtexas"
+export LOCATION="usgovvirginia"
 export WORKSPACE="tmp_gov$BUILD_BUILDID"
 export SUBSCRIPTION_ID="$ARM_SUBSCRIPTION_ID"
 

--- a/scripts/environments/usgov-ia.env
+++ b/scripts/environments/usgov-ia.env
@@ -1,6 +1,6 @@
 # Region to deploy into when running locally.
 # This is set by the Azure Pipeline for other environments.
-export LOCATION="usgovarizona"
+export LOCATION="usgovtexas"
 export WORKSPACE="tmp_gov$BUILD_BUILDID"
 export SUBSCRIPTION_ID="$ARM_SUBSCRIPTION_ID"
 


### PR DESCRIPTION
This pull request includes an update to the `functions/requirements.txt` file to upgrade the `nltk` library version.

* [`functions/requirements.txt`](diffhunk://#diff-ffed1292290bc75db46497dd6cceb5ef131ea608989b260cb70aaaea0b30f2f9L15-R15): Upgraded `nltk` from version 3.8.1 to 3.9.