### PR TITLE
Updated to full connection string to support all regions

### DIFF
--- a/infra/core/host/functions/outputs.tf
+++ b/infra/core/host/functions/outputs.tf
@@ -14,18 +14,6 @@ output "identityPrincipalId" {
   value = azurerm_linux_function_app.function_app.identity.0.principal_id
 }
 
-output "AzureWebJobsStorage__accountName" {
-  value = var.blobStorageAccountName
-}
-
-output "AzureWebJobsStorage__blobServiceUri" {
-  value = "https://${var.blobStorageAccountName}.blob.${var.endpointSuffix}"
-}
-
-output "STORAGE_CONNECTION_STRING__accountName" {
-  value = var.blobStorageAccountName
-}
-
 output "STORAGE_CONNECTION_STRING__queueServiceUri" {
   value = "https://${var.blobStorageAccountName}.queue.${var.endpointSuffix}"
 }

--- a/infra/core/storage/storage-account.tf
+++ b/infra/core/storage/storage-account.tf
@@ -189,7 +189,7 @@ module "storage_connection_string" {
   arm_template_schema_mgmt_api  = var.arm_template_schema_mgmt_api
   key_vault_name                = var.key_vault_name
   secret_name                   = "AZURE-STORAGE-CONNECTION-STRING"
-  secret_value                  = azurerm_storage_account.storage.primary_blob_connection_string
+  secret_value                  = azurerm_storage_account.storage.primary_connection_string
   tags                          = var.tags
   alias                         = "blobconnstring"
   kv_secret_expiration          = var.kv_secret_expiration

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -208,18 +208,6 @@ output "AZURE_AI_CREDENTIAL_DOMAIN" {
   value = var.azure_ai_private_link_domain
 }
 
-output "FUNC_AzureWebJobsStorage__accountName" {
-  value = module.functions.AzureWebJobsStorage__accountName
-}
-
-output "FUNC_AzureWebJobsStorage__blobServiceUri" {
-  value = module.functions.AzureWebJobsStorage__blobServiceUri
-}
-
-output "FUNC_STORAGE_CONNECTION_STRING__accountName" {
-  value = module.functions.STORAGE_CONNECTION_STRING__accountName
-}
-
 output "FUNC_STORAGE_CONNECTION_STRING__queueServiceUri" {
   value = module.functions.STORAGE_CONNECTION_STRING__queueServiceUri
 }

--- a/scripts/json-to-env.function.debug.sh
+++ b/scripts/json-to-env.function.debug.sh
@@ -86,18 +86,6 @@ jq -r --arg secrets "$secrets" '
             "env_var": "COSMOSDB_LOG_CONTAINER_NAME"
         },
         {
-            "path": "FUNC_AzureWebJobsStorage__accountName",
-            "env_var": "AzureWebJobsStorage__accountName"
-        },
-        {
-            "path": "FUNC_AzureWebJobsStorage__blobServiceUri",
-            "env_var": "AzureWebJobsStorage__blobServiceUri"
-        },
-        {
-            "path": "FUNC_STORAGE_CONNECTION_STRING__accountName",
-            "env_var": "AzureStorageConnection1__accountName"
-        },
-        {
             "path": "FUNC_STORAGE_CONNECTION_STRING__queueServiceUri",
             "env_var": "AzureStorageConnection1__queueServiceUri"
         },


### PR DESCRIPTION
This pull request primarily focuses on cleaning up and simplifying the configuration and output of storage-related settings in the infrastructure files. The most important changes include the removal of several output variables and the modification of a storage connection string reference.

### Removal of Output Variables:
* [`infra/core/host/functions/outputs.tf`](diffhunk://#diff-1abec27d197247cc00a4e3ee7d76900ae4ba78191400b609b8861b911ea49ae9L17-L28): Removed output variables `AzureWebJobsStorage__accountName`, `AzureWebJobsStorage__blobServiceUri`, and `STORAGE_CONNECTION_STRING__accountName`.
* [`infra/outputs.tf`](diffhunk://#diff-f99da7494a3eef65426a69531706ba9db03cb7923513eac03394f69d051410c7L211-L222): Removed output variables `FUNC_AzureWebJobsStorage__accountName`, `FUNC_AzureWebJobsStorage__blobServiceUri`, and `FUNC_STORAGE_CONNECTION_STRING__accountName`.

### Modification of Storage Connection String:
* [`infra/core/storage/storage-account.tf`](diffhunk://#diff-71dbcf10522b5459b6154471d0ad089a5fe2e30f8ea943c5fb8806896eef75bbL192-R192): Changed the `secret_value` to use `azurerm_storage_account.storage.primary_connection_string` instead of `azurerm_storage_account.storage.primary_blob_connection_string`.

### Script Adjustments:
* [`scripts/json-to-env.function.debug.sh`](diffhunk://#diff-a31a8e24d2063d8adc93f14fb15aafcdc562f95b2ec0abdc640d386aceb34c91L88-L99): Removed entries related to `FUNC_AzureWebJobsStorage__accountName`, `FUNC_AzureWebJobsStorage__blobServiceUri`, and `FUNC_STORAGE_CONNECTION_STRING__accountName`.