### PR TITLE
Cleanup of AzDO pipeline docs to identify as examples

### DIFF
--- a/pipelines/README.md
+++ b/pipelines/README.md
@@ -1,5 +1,5 @@
 # Azure DevOps Pipelines
 
-This folder contains files that constitute Azure DevOps Pipelines.
+This folder contains files that are examples of Azure DevOps Pipelines.
 
-Setting up a pipeline to deploy a new Sandbox environment requires some manual configuration. Review the details of the [Procedure to setup sandbox environment](/docs/deployment/setting_up_sandbox_environment.md) here.
+These are examples only and setting up a pipeline to deploy a new Sandbox environment requires additional manual configuration. Review the details of the [Setting up a sandbox environment](/docs/deployment/setting_up_sandbox_environment.md) here.


### PR DESCRIPTION
This pull request includes several updates to the documentation for setting up a sandbox environment using Azure DevOps pipelines. The primary focus is on clarifying the setup process and updating terminology to reflect current practices. Additionally, it highlights the need for manual configurations and provides warnings about the limitations of the example pipelines.

### Documentation Updates:

* **General Terminology and Clarity Improvements:**
  * Updated the title and content to reflect that the guide is for deploying a sandbox environment, not just setting up CI/CD pipelines. (`docs/deployment/setting_up_sandbox_environment.md`)
  * Clarified that the provided example pipelines require manual changes to be fully functional. (`docs/deployment/setting_up_sandbox_environment.md`)
  * Changed references from "Azure Active Directory" to "Azure Entra" to align with current terminology. (`docs/deployment/setting_up_sandbox_environment.md`)

* **Variable Configuration:**
  * Added warnings about additional variables that might be needed for a fully functioning deployment and emphasized the importance of protecting sensitive information. (`docs/deployment/setting_up_sandbox_environment.md`)

* **Image Path Fix:**
  * Corrected the image path for pipeline configuration. (`docs/deployment/setting_up_sandbox_environment.md`)

* **Pipeline Examples:**
  * Updated the `README.md` in the `pipelines` folder to clarify that the provided files are examples and additional manual configuration is required. (`pipelines/README.md`)