### PR TITLE
change view back to document section on click of another citation

### DIFF
--- a/app/frontend/src/components/AnalysisPanel/AnalysisPanel.tsx
+++ b/app/frontend/src/components/AnalysisPanel/AnalysisPanel.tsx
@@ -32,6 +32,8 @@ const pivotItemDisabledStyle: React.CSSProperties = {
 };
 
 export const AnalysisPanel = ({ answer, activeTab, activeCitation, sourceFile, pageNumber, citationHeight, className, onActiveTabChanged }: Props) => {
+    
+    const [innerPivotTab, setInnerPivotTab] = useState<string>('indexedFile');
     const [activeCitationObj, setActiveCitationObj] = useState<ActiveCitation>();
     const [markdownContent, setMarkdownContent] = useState('');
     const [plainTextContent, setPlainTextContent] = useState('');
@@ -99,6 +101,9 @@ export const AnalysisPanel = ({ answer, activeTab, activeCitation, sourceFile, p
     }
 
     useEffect(() => {
+        if (activeCitation) {
+            setInnerPivotTab('indexedFile');
+        }
         fetchActiveCitationObj();
     }, [activeCitation]);
 
@@ -175,7 +180,14 @@ export const AnalysisPanel = ({ answer, activeTab, activeCitation, sourceFile, p
                 onRenderItemLink = {onRenderItemLink("No active citation selected. Please select a citation from the citations list on the left.", tooltipRef3, isDisabledCitationTab)}
             > 
             
-                <Pivot className={className}>
+                <Pivot className={className} selectedKey={innerPivotTab} onLinkClick={(item) => {
+                    if (item) {
+                        setInnerPivotTab(item.props.itemKey!);
+                    } else {
+                        // Handle the case where item is undefined
+                        console.warn('Item is undefined');
+                    }
+                }}>
                     <PivotItem itemKey="indexedFile" headerText="Document Section">
                         {activeCitationObj === undefined ? (
                             <Text>Loading...</Text>


### PR DESCRIPTION
This pull request includes changes to the `AnalysisPanel` component in the `app/frontend/src/components/AnalysisPanel/AnalysisPanel.tsx` file. The updates introduce a new state variable to manage the selected tab in the `Pivot` component and ensure the tab is reset when an active citation is selected.

Key changes:

### State Management Enhancements:
* Added a new state variable `innerPivotTab` to manage the selected tab in the `Pivot` component. (`app/frontend/src/components/AnalysisPanel/AnalysisPanel.tsx`, [app/frontend/src/components/AnalysisPanel/AnalysisPanel.tsxR35-R36](diffhunk://#diff-1c152a9cc611df2db331cd06ae6145ca33249071c2e6c4cf1ae02cb0ea7b8970R35-R36))

### Effect Hook Updates:
* Updated the `useEffect` hook to reset the `innerPivotTab` to 'indexedFile' whenever `activeCitation` changes. (`app/frontend/src/components/AnalysisPanel/AnalysisPanel.tsx`, [app/frontend/src/components/AnalysisPanel/AnalysisPanel.tsxR104-R106](diffhunk://#diff-1c152a9cc611df2db331cd06ae6145ca33249071c2e6c4cf1ae02cb0ea7b8970R104-R106))

### Pivot Component Updates:
* Modified the `Pivot` component to use the `innerPivotTab` state for the `selectedKey` prop and added an `onLinkClick` handler to update the state when a different tab is selected. (`app/frontend/src/components/AnalysisPanel/AnalysisPanel.tsx`, [app/frontend/src/components/AnalysisPanel/AnalysisPanel.tsxL178-R190](diffhunk://#diff-1c152a9cc611df2db331cd06ae6145ca33249071c2e6c4cf1ae02cb0ea7b8970L178-R190))