### PR TITLE
Enable Diagnostic Settings for PubSec-Info-Assistant Resources in Terraform

### DIFF
--- a/infra/core/ai/cogServices/cogServices.tf
+++ b/infra/core/ai/cogServices/cogServices.tf
@@ -7,6 +7,26 @@ resource "azurerm_cognitive_account" "cognitiveService" {
   tags                     = var.tags
 }
 
+resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
+  name                       = var.name
+  target_resource_id         = azurerm_cognitive_account.cognitiveService.id
+  log_analytics_workspace_id = var.logAnalyticsWorkspaceResourceId
+
+  enabled_log {
+    category = "Audit"
+  }
+  enabled_log {
+    category = "RequestResponse"
+  }
+  enabled_log {
+    category = "Trace"
+  }
+  metric {
+    category = "AllMetrics"
+    enabled  = true
+  }
+}
+
 resource "azurerm_key_vault_secret" "search_service_key" {
   name         = "ENRICHMENT-KEY"
   value        = azurerm_cognitive_account.cognitiveService.primary_access_key

--- a/infra/core/ai/cogServices/variables.tf
+++ b/infra/core/ai/cogServices/variables.tf
@@ -44,3 +44,7 @@ variable "resourceGroupName" {
 variable "keyVaultId" { 
   type = string
 }
+
+variable "logAnalyticsWorkspaceResourceId" {
+  type = string
+}

--- a/infra/core/ai/docintelligence/formrecognizer.tf
+++ b/infra/core/ai/docintelligence/formrecognizer.tf
@@ -9,6 +9,26 @@ resource "azurerm_cognitive_account" "formRecognizerAccount" {
   tags                     = var.tags
 }
 
+resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
+  name                       = var.name
+  target_resource_id         = azurerm_cognitive_account.formRecognizerAccount.id
+  log_analytics_workspace_id = var.logAnalyticsWorkspaceResourceId
+
+  enabled_log {
+    category = "Audit"
+  }
+  enabled_log {
+    category = "RequestResponse"
+  }
+  enabled_log {
+    category = "Trace"
+  }
+  metric {
+    category = "AllMetrics"
+    enabled  = true
+  }
+}
+
 resource "azurerm_key_vault_secret" "docIntelligenceKey" {
   name         = "AZURE-FORM-RECOGNIZER-KEY"
   value        = azurerm_cognitive_account.formRecognizerAccount.primary_access_key

--- a/infra/core/ai/docintelligence/variables.tf
+++ b/infra/core/ai/docintelligence/variables.tf
@@ -48,3 +48,7 @@ variable "resourceGroupName" {
 variable "keyVaultId" { 
   type = string
 }
+
+variable "logAnalyticsWorkspaceResourceId" {
+  type = string
+}

--- a/infra/core/ai/openaiservices/openaiservices.tf
+++ b/infra/core/ai/openaiservices/openaiservices.tf
@@ -9,6 +9,27 @@ resource "azurerm_cognitive_account" "account" {
   tags = var.tags
 }
 
+resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
+  count                           = var.useExistingAOAIService ? 0 : 1
+  name                            = var.name
+  target_resource_id              = azurerm_cognitive_account.account[0].id
+  log_analytics_workspace_id      = var.logAnalyticsWorkspaceResourceId
+
+  enabled_log {
+    category = "Audit"
+  }
+  enabled_log {
+    category = "RequestResponse"
+  }
+  enabled_log {
+    category = "Trace"
+  }
+  metric {
+    category = "AllMetrics"
+    enabled  = true
+  }
+}
+
 resource "azurerm_cognitive_deployment" "deployment" {
   count                 = var.useExistingAOAIService ? 0 : length(var.deployments)
   name                  = var.deployments[count.index].name

--- a/infra/core/ai/openaiservices/variables.tf
+++ b/infra/core/ai/openaiservices/variables.tf
@@ -54,3 +54,7 @@ variable "openaiServiceKey" {
   description = "The OpenAI service key"
   type        = string
 }
+
+variable "logAnalyticsWorkspaceResourceId" {
+  type = string
+}

--- a/infra/core/db/cosmosdb.tf
+++ b/infra/core/db/cosmosdb.tf
@@ -52,6 +52,45 @@ resource "azurerm_cosmosdb_account" "cosmosdb_account" {
   tags = var.tags
 }
 
+resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
+  name                       = lower(var.name)
+  target_resource_id         = azurerm_cosmosdb_account.cosmosdb_account.id
+  log_analytics_workspace_id = var.logAnalyticsWorkspaceResourceId
+
+  enabled_log {
+    category = "DataPlaneRequests"
+  }
+  enabled_log {
+    category = "MongoRequests"
+  }
+  enabled_log {
+    category = "QueryRuntimeStatistics"
+  }
+  enabled_log {
+    category = "PartitionKeyStatistics"
+  }
+  enabled_log {
+    category = "PartitionKeyRUConsumption"
+  }
+  enabled_log {
+    category = "ControlPlaneRequests"
+  }
+  enabled_log {
+    category = "CassandraRequests"
+  }
+  enabled_log {
+    category = "GremlinRequests"
+  }
+  enabled_log {
+    category = "TableApiRequests"
+  }
+
+  metric {
+    category = "AllMetrics"
+    enabled  = true
+  }
+}
+
 resource "azurerm_cosmosdb_sql_database" "log_database" {
   name                = var.logDatabaseName
   resource_group_name = var.resourceGroupName

--- a/infra/core/db/variables.tf
+++ b/infra/core/db/variables.tf
@@ -64,3 +64,7 @@ variable "resourceGroupName" {
 variable "keyVaultId" { 
   type = string
 }
+
+variable "logAnalyticsWorkspaceResourceId" {
+  type = string
+}

--- a/infra/core/host/enrichmentapp/enrichmentapp.tf
+++ b/infra/core/host/enrichmentapp/enrichmentapp.tf
@@ -13,6 +13,17 @@ resource "azurerm_service_plan" "appServicePlan" {
   zone_balancing_enabled        = false
 }
 
+resource "azurerm_monitor_diagnostic_setting" "appServicePlan" {
+  name                       = var.plan_name
+  target_resource_id         = azurerm_service_plan.appServicePlan.id
+  log_analytics_workspace_id = var.logAnalyticsWorkspaceResourceId
+
+  metric {
+    category = "AllMetrics"
+    enabled  = true
+  }
+}
+
 resource "azurerm_monitor_autoscale_setting" "scaleout" {
   name                = azurerm_service_plan.appServicePlan.name
   resource_group_name = var.resourceGroupName
@@ -164,13 +175,11 @@ resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
   enabled_log {
     category = "AppServiceConsoleLogs"
   }
-
   metric {
     category = "AllMetrics"
     enabled  = true
   }
 }
-
 
 output "name" {
   value = azurerm_linux_web_app.app_service.name

--- a/infra/core/host/functions/functions.tf
+++ b/infra/core/host/functions/functions.tf
@@ -10,6 +10,17 @@ resource "azurerm_service_plan" "funcServicePlan" {
   tags = var.tags
 }
 
+resource "azurerm_monitor_diagnostic_setting" "funcServicePlan" {
+  name                       = var.plan_name
+  target_resource_id         = azurerm_service_plan.funcServicePlan.id
+  log_analytics_workspace_id = var.logAnalyticsWorkspaceResourceId
+
+  metric {
+    category = "AllMetrics"
+    enabled  = true
+  }
+}
+
 resource "azurerm_monitor_autoscale_setting" "scaleout" {
   name                = azurerm_service_plan.funcServicePlan.name
   resource_group_name = var.resourceGroupName
@@ -165,6 +176,22 @@ resource "azurerm_linux_function_app" "function_app" {
   }
 }
 
+resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
+  name                            = var.name
+  target_resource_id              = azurerm_linux_function_app.function_app.id
+  log_analytics_workspace_id      = var.logAnalyticsWorkspaceResourceId
+
+  enabled_log {
+    category = "FunctionAppLogs"
+  }
+  enabled_log {
+    category = "AppServiceAuthenticationLogs"
+  }
+  metric {
+    category = "AllMetrics"
+    enabled  = true
+  }
+}
 
 resource "azurerm_key_vault_access_policy" "policy" {
   key_vault_id = data.azurerm_key_vault.existing_kv.id

--- a/infra/core/host/functions/variables.tf
+++ b/infra/core/host/functions/variables.tf
@@ -247,3 +247,7 @@ variable "endpointSuffix" {
   type    = string
   default = "core.windows.net"
 }
+
+variable "logAnalyticsWorkspaceResourceId" {
+  type = string
+}

--- a/infra/core/host/webapp/webapp.tf
+++ b/infra/core/host/webapp/webapp.tf
@@ -12,6 +12,17 @@ resource "azurerm_service_plan" "appServicePlan" {
   tags = var.tags
 }
 
+resource "azurerm_monitor_diagnostic_setting" "appServicePlan" {
+  name                       = var.plan_name
+  target_resource_id         = azurerm_service_plan.appServicePlan.id
+  log_analytics_workspace_id = var.logAnalyticsWorkspaceResourceId
+
+  metric {
+    category = "AllMetrics"
+    enabled  = true
+  }
+}
+
 resource "azurerm_monitor_autoscale_setting" "scaleout" {
   name                = azurerm_service_plan.appServicePlan.name
   resource_group_name = var.resourceGroupName
@@ -179,7 +190,6 @@ resource "azurerm_monitor_diagnostic_setting" "diagnostic_logs" {
   enabled_log {
     category = "AppServiceConsoleLogs"
   }
-
   metric {
     category = "AllMetrics"
     enabled  = true

--- a/infra/core/logging/loganalytics/logging.tf
+++ b/infra/core/logging/loganalytics/logging.tf
@@ -8,6 +8,23 @@ resource "azurerm_log_analytics_workspace" "logAnalytics" {
   retention_in_days   = 30
 }
 
+resource "azurerm_monitor_diagnostic_setting" "logAnalytics" {
+  name                       = var.logAnalyticsName
+  target_resource_id         = azurerm_log_analytics_workspace.logAnalytics.id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.logAnalytics.id
+
+  enabled_log {
+    category = "Audit"
+  }
+  enabled_log {
+    category = "SummaryLogs"
+  }
+  metric {
+    category = "AllMetrics"
+    enabled  = true
+  }
+}
+
 resource "azurerm_application_insights" "applicationInsights" {
   name                = var.applicationInsightsName
   location            = var.location
@@ -15,6 +32,50 @@ resource "azurerm_application_insights" "applicationInsights" {
   application_type    = "web"
   tags                = var.tags
   workspace_id        = azurerm_log_analytics_workspace.logAnalytics.id
+}
+
+resource "azurerm_monitor_diagnostic_setting" "applicationInsights" {
+  name                       = var.applicationInsightsName
+  target_resource_id         = azurerm_application_insights.applicationInsights.id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.logAnalytics.id
+
+  enabled_log {
+    category = "AppAvailabilityResults"
+  }
+  enabled_log {
+    category = "AppBrowserTimings"
+  }
+  enabled_log {
+    category = "AppEvents"
+  }
+  enabled_log {
+    category = "AppMetrics"
+  }
+  enabled_log {
+    category = "AppDependencies"
+  }
+  enabled_log {
+    category = "AppExceptions"
+  }
+  enabled_log {
+    category = "AppPageViews"
+  }
+  enabled_log {
+    category = "AppPerformanceCounters"
+  }
+  enabled_log {
+    category = "AppRequests"
+  }
+  enabled_log {
+    category = "AppSystemEvents"
+  }
+  enabled_log {
+    category = "AppTraces"
+  }
+  metric {
+    category = "AllMetrics"
+    enabled  = true
+  }
 }
 
 output "applicationInsightsId" {

--- a/infra/core/search/search-services.tf
+++ b/infra/core/search/search-services.tf
@@ -16,6 +16,20 @@ resource "azurerm_search_service" "search" {
   semantic_search_sku           = var.semanticSearch 
 }
 
+resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
+  name                            = var.name
+  target_resource_id              = azurerm_search_service.search.id
+  log_analytics_workspace_id      = var.logAnalyticsWorkspaceResourceId
+
+  enabled_log {
+    category = "OperationLogs"
+  }
+  metric {
+    category = "AllMetrics"
+    enabled  = true
+  }
+}
+
 resource "azurerm_key_vault_secret" "search_service_key" {
   name         = "AZURE-SEARCH-SERVICE-KEY"
   value        = data.azurerm_search_service.search.primary_key

--- a/infra/core/search/variables.tf
+++ b/infra/core/search/variables.tf
@@ -41,3 +41,7 @@ variable "keyVaultId" {
 variable "azure_search_domain" {
   type = string  
 }
+
+variable "logAnalyticsWorkspaceResourceId" {
+  type = string
+}

--- a/infra/core/security/keyvault/keyvault.tf
+++ b/infra/core/security/keyvault/keyvault.tf
@@ -12,7 +12,23 @@ resource "azurerm_key_vault" "kv" {
   purge_protection_enabled    = true
 }
 
- 
+resource "azurerm_monitor_diagnostic_setting" "diagnostic_setting" {
+  name                            = var.name
+  target_resource_id              = azurerm_key_vault.kv.id
+  log_analytics_workspace_id      = var.logAnalyticsWorkspaceResourceId
+
+  enabled_log {
+    category = "AuditEvent"
+  }
+  enabled_log {
+    category = "AzurePolicyEvaluationDetails"
+  }
+  metric {
+    category = "AllMetrics"
+    enabled  = true
+  }
+}
+
 resource "azurerm_key_vault_access_policy" "infoasst" {
   depends_on  = [
     azurerm_key_vault.kv

--- a/infra/core/security/keyvault/variables.tf
+++ b/infra/core/security/keyvault/variables.tf
@@ -48,3 +48,7 @@ variable "resourceGroupName" {
   type    = string
   default = ""
 }
+
+variable "logAnalyticsWorkspaceResourceId" {
+  type = string
+}

--- a/infra/core/storage/storage-account.tf
+++ b/infra/core/storage/storage-account.tf
@@ -37,7 +37,116 @@ resource "azurerm_storage_account" "storage" {
     }
 }
 
+resource "azurerm_monitor_diagnostic_setting" "diagnostic_logs" {
+  name                       = var.name
+  target_resource_id         = azurerm_storage_account.storage.id
+  log_analytics_workspace_id = var.logAnalyticsWorkspaceResourceId
 
+  metric {
+    category = "Capacity"
+    enabled  = true
+  }
+  metric {
+    category = "Transaction"
+    enabled  = true
+  }
+}
+
+resource "azurerm_monitor_diagnostic_setting" "diagnostic_logs_file" {
+  name                       = var.name
+  target_resource_id         = "${azurerm_storage_account.storage.id}/fileServices/default"
+  log_analytics_workspace_id = var.logAnalyticsWorkspaceResourceId
+
+  enabled_log {
+    category = "StorageRead"
+  }
+  enabled_log {
+    category = "StorageWrite"
+  }
+  enabled_log {
+    category = "StorageDelete"
+  }
+  metric {
+    category = "Capacity"
+    enabled  = true
+  }
+  metric {
+    category = "Transaction"
+    enabled  = true
+  }
+}
+
+resource "azurerm_monitor_diagnostic_setting" "diagnostic_logs_table" {
+  name                       = var.name
+  target_resource_id         = "${azurerm_storage_account.storage.id}/tableServices/default"
+  log_analytics_workspace_id = var.logAnalyticsWorkspaceResourceId
+
+  enabled_log {
+    category = "StorageRead"
+  }
+  enabled_log {
+    category = "StorageWrite"
+  }
+  enabled_log {
+    category = "StorageDelete"
+  }
+  metric {
+    category = "Capacity"
+    enabled  = true
+  }
+  metric {
+    category = "Transaction"
+    enabled  = true
+  }
+}
+
+resource "azurerm_monitor_diagnostic_setting" "diagnostic_logs_queue" {
+  name                       = var.name
+  target_resource_id         = "${azurerm_storage_account.storage.id}/queueServices/default"
+  log_analytics_workspace_id = var.logAnalyticsWorkspaceResourceId
+
+  enabled_log {
+    category = "StorageRead"
+  }
+  enabled_log {
+    category = "StorageWrite"
+  }
+  enabled_log {
+    category = "StorageDelete"
+  }
+  metric {
+    category = "Capacity"
+    enabled  = true
+  }
+  metric {
+    category = "Transaction"
+    enabled  = true
+  }
+}
+
+resource "azurerm_monitor_diagnostic_setting" "diagnostic_logs_blob" {
+  name                       = var.name
+  target_resource_id         = "${azurerm_storage_account.storage.id}/blobServices/default"
+  log_analytics_workspace_id = var.logAnalyticsWorkspaceResourceId
+
+  enabled_log {
+    category = "StorageRead"
+  }
+  enabled_log {
+    category = "StorageWrite"
+  }
+  enabled_log {
+    category = "StorageDelete"
+  }
+  metric {
+    category = "Capacity"
+    enabled  = true
+  }
+  metric {
+    category = "Transaction"
+    enabled  = true
+  }
+}
 
 resource "azurerm_storage_container" "container" {
   count = length(var.containers)

--- a/infra/core/storage/variables.tf
+++ b/infra/core/storage/variables.tf
@@ -89,3 +89,7 @@ variable "resourceGroupName" {
 variable "keyVaultId" { 
   type = string
 }
+
+variable "logAnalyticsWorkspaceResourceId" {
+  type = string
+}

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -61,6 +61,7 @@ module "storage" {
   }
   containers            = ["content","website","upload","function","logs","config"]
   queueNames            = ["pdf-submit-queue","pdf-polling-queue","non-pdf-submit-queue","media-submit-queue","text-enrichment-queue","image-enrichment-queue","embeddings-queue"]
+  logAnalyticsWorkspaceResourceId = module.logging.logAnalyticsId
   depends_on = [
     module.kvModule
   ]
@@ -197,6 +198,7 @@ module "openaiServices" {
   resourceGroupName = azurerm_resource_group.rg.name
   keyVaultId = module.kvModule.keyVaultId
   openaiServiceKey = var.azureOpenAIServiceKey
+  logAnalyticsWorkspaceResourceId = module.logging.logAnalyticsId
   useExistingAOAIService = var.useExistingAOAIService
 
   deployments = [
@@ -237,6 +239,8 @@ module "formrecognizer" {
   customSubDomainName = "infoasst-fr-${random_string.random.result}"
   resourceGroupName = azurerm_resource_group.rg.name
   keyVaultId = module.kvModule.keyVaultId 
+  logAnalyticsWorkspaceResourceId = module.logging.logAnalyticsId
+
   depends_on = [
     module.kvModule
   ]
@@ -250,6 +254,8 @@ module "cognitiveServices" {
   tags     = local.tags
   keyVaultId = module.kvModule.keyVaultId 
   resourceGroupName = azurerm_resource_group.rg.name
+  logAnalyticsWorkspaceResourceId = module.logging.logAnalyticsId
+
   depends_on = [
     module.kvModule
   ]
@@ -267,6 +273,7 @@ module "searchServices" {
   resourceGroupName = azurerm_resource_group.rg.name
   keyVaultId = module.kvModule.keyVaultId
   azure_search_domain = var.azure_search_domain
+  logAnalyticsWorkspaceResourceId = module.logging.logAnalyticsId
 
   depends_on = [
     module.kvModule
@@ -283,7 +290,8 @@ module "cosmosdb" {
   logContainerName  = "statuscontainer"
   resourceGroupName = azurerm_resource_group.rg.name
   keyVaultId        = module.kvModule.keyVaultId  
-  
+  logAnalyticsWorkspaceResourceId = module.logging.logAnalyticsId
+
   depends_on = [
     module.kvModule
   ]
@@ -347,6 +355,7 @@ module "functions" {
   azureSearchIndex                      = var.searchIndexName
   azureSearchServiceEndpoint            = module.searchServices.endpoint
   endpointSuffix                        = var.azure_storage_domain
+  logAnalyticsWorkspaceResourceId       = module.logging.logAnalyticsId
 
   depends_on = [
     module.storage,
@@ -486,6 +495,7 @@ module "kvModule" {
   source            = "./core/security/keyvault" 
   name              = "infoasst-kv-${random_string.random.result}"
   location          = var.location
+  logAnalyticsWorkspaceResourceId = module.logging.logAnalyticsId
   kvAccessObjectId  = data.azurerm_client_config.current.object_id 
   spClientSecret    = module.entraObjects.azure_ad_mgmt_app_secret 
   subscriptionId    = var.subscriptionId


### PR DESCRIPTION
Enable the diagnostic settings for the Azure Resources deployed by the PubSec-Info-Assistant solution via Terraform to allow troubleshooting and monitoring.