### PR TITLE
File progress reversion

### DIFF
--- a/app/frontend/src/components/filepicker/file-picker.tsx
+++ b/app/frontend/src/components/filepicker/file-picker.tsx
@@ -81,13 +81,14 @@ const FilePicker = ({ folderPath, tags }: Props) => {
             state: StatusLogState.Uploaded,  
           };  
           await logStatus(logEntry);
-          // Increment the counter for successfully uploaded files
-          uploadedFilesCount++;
-          setProgress((uploadedFilesCount / files.length) * 100);
-  
+          
         } catch (error) {  
           console.log("Unable to upload file " + filePath + " : Error: " + error);  
-        }        
+        }  
+        // Increment the counter for successfully uploaded files
+        uploadedFilesCount++;
+        setProgress((uploadedFilesCount / files.length) * 100);
+      
       });
   
       await Promise.all(uploadPromises);  

--- a/app/frontend/src/components/filepicker/file-picker.tsx
+++ b/app/frontend/src/components/filepicker/file-picker.tsx
@@ -46,6 +46,7 @@ const FilePicker = ({ folderPath, tags }: Props) => {
       const data = new FormData();  
       console.log("files", files);  
       setUploadStarted(true);  
+      let uploadedFilesCount = 0;
   
       const uploadPromises = files.map(async (indexedFile:any, index:any) => {  
         const file = indexedFile.file as File;  
@@ -79,12 +80,14 @@ const FilePicker = ({ folderPath, tags }: Props) => {
             status_classification: StatusLogClassification.Info,  
             state: StatusLogState.Uploaded,  
           };  
-          await logStatus(logEntry);  
+          await logStatus(logEntry);
+          // Increment the counter for successfully uploaded files
+          uploadedFilesCount++;
+          setProgress((uploadedFilesCount / files.length) * 100);
+  
         } catch (error) {  
           console.log("Unable to upload file " + filePath + " : Error: " + error);  
-        }  
-  
-        setProgress(((index + 1) / files.length) * 100);  
+        }        
       });
   
       await Promise.all(uploadPromises);  


### PR DESCRIPTION
This pull request includes improvements to the file upload progress tracking in the `FilePicker` component. The changes ensure a more accurate progress indication by counting successfully uploaded files.

Enhancements to file upload progress tracking:

* [`app/frontend/src/components/filepicker/file-picker.tsx`](diffhunk://#diff-657c186d39a0173a31fdb99be1ab78f336140a9c03e85adb601f66fbb18d2475R49): Introduced a new variable `uploadedFilesCount` to track the number of successfully uploaded files.
* [`app/frontend/src/components/filepicker/file-picker.tsx`](diffhunk://#diff-657c186d39a0173a31fdb99be1ab78f336140a9c03e85adb601f66fbb18d2475R84-L87): Updated the progress calculation to use `uploadedFilesCount` instead of the file index, ensuring progress reflects only successful uploads.