### PR TITLE
Add health_check_eviction_time_in_min to WebApp Health Check

### DIFF
--- a/infra/core/host/webapp/webapp.tf
+++ b/infra/core/host/webapp/webapp.tf
@@ -92,12 +92,13 @@ resource "azurerm_linux_web_app" "app_service" {
       docker_registry_username  = var.container_registry_admin_username
       docker_registry_password  = var.container_registry_admin_password
     }
-    container_registry_use_managed_identity       = true
-    always_on                      = var.alwaysOn
-    ftps_state                     = var.is_secure_mode ? "Disabled" : var.ftpsState
-    app_command_line               = var.appCommandLine
-    health_check_path              = var.healthCheckPath
-    
+    container_registry_use_managed_identity = true
+    always_on                               = var.alwaysOn
+    ftps_state                              = var.is_secure_mode ? "Disabled" : var.ftpsState
+    app_command_line                        = var.appCommandLine
+    health_check_path                       = var.healthCheckPath
+    health_check_eviction_time_in_min       = 10
+
     cors {
       allowed_origins = concat([var.azure_portal_domain, "https://ms.portal.azure.com"], var.allowedOrigins)
     }


### PR DESCRIPTION
This pull request includes a small but important change to the `infra/core/host/webapp/webapp.tf` file. The change adds a new configuration setting to the `azurerm_linux_web_app` resource.

* [`infra/core/host/webapp/webapp.tf`](diffhunk://#diff-84a6fe1025c26de1143712bc4ec7ab29fe949ee00414845ed531592abfd29866R100): Added `health_check_eviction_time_in_min` with a value of 10 to the `azurerm_linux_web_app` resource.

fixes #860 