### PR TITLE
Terraform AzureRM 4.x.x Provider Support

### DIFF
--- a/infra/core/ai/openaiservices/openaiservices.tf
+++ b/infra/core/ai/openaiservices/openaiservices.tf
@@ -34,9 +34,9 @@ resource "azurerm_cognitive_deployment" "deployment" {
     name                = var.deployments[count.index].model.name
     version             = var.deployments[count.index].model.version
   }
-  scale {
-    type                = var.deployments[count.index].sku_name
-    capacity            = var.deployments[count.index].sku_capacity
+  sku {
+    name                = var.deployments[count.index].sku.name
+    capacity            = var.deployments[count.index].sku.capacity
   }
 }
 

--- a/infra/core/storage/storage-account.tf
+++ b/infra/core/storage/storage-account.tf
@@ -12,7 +12,7 @@ resource "azurerm_storage_account" "storage" {
   account_replication_type        = "LRS"
   access_tier                     = var.accessTier
   min_tls_version                 = var.minimumTlsVersion
-  enable_https_traffic_only       = true
+  https_traffic_only_enabled      = true
   public_network_access_enabled   = var.is_secure_mode ? false : true
   allow_nested_items_to_be_public = false
   shared_access_key_enabled       = true #var.is_secure_mode ? false : true # This will need to be enabled once the Azure Functions can support Entra ID auth

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -515,8 +515,10 @@ module "openaiServices" {
         name          = var.chatGptModelName != "" ? var.chatGptModelName : "gpt-35-turbo-16k"
         version       = var.chatGptModelVersion != "" ? var.chatGptModelVersion : "0613"
       }
-      sku_name        = var.chatGptModelSkuName
-      sku_capacity    = var.chatGptDeploymentCapacity
+      sku             = {
+        name          = var.chatGptModelSkuName
+        capacity      = var.chatGptDeploymentCapacity
+      }
       rai_policy_name = "Microsoft.Default"
     },
     {
@@ -526,8 +528,10 @@ module "openaiServices" {
         name          = var.azureOpenAIEmbeddingsModelName != "" ? var.azureOpenAIEmbeddingsModelName : "text-embedding-ada-002"
         version       = "2"
       }
-      sku_name        = var.azureOpenAIEmbeddingsModelSku
-      sku_capacity    = var.embeddingsDeploymentCapacity
+      sku             = {
+        name          = var.azureOpenAIEmbeddingsModelSku
+        capacity      = var.embeddingsDeploymentCapacity
+      }
       rai_policy_name = "Microsoft.Default"
     }
   ]

--- a/infra/providers.tf
+++ b/infra/providers.tf
@@ -27,7 +27,6 @@ provider "azurerm" {
       recover_soft_deleted_key_vaults = true
     }
   }
-  skip_provider_registration = true
   storage_use_azuread = true
   environment = var.azure_environment == "AzureUSGovernment" ? "usgovernment" : "public"
 }

--- a/infra/providers.tf
+++ b/infra/providers.tf
@@ -27,6 +27,7 @@ provider "azurerm" {
       recover_soft_deleted_key_vaults = true
     }
   }
+  resource_provider_registrations = "none"
   storage_use_azuread = true
   environment = var.azure_environment == "AzureUSGovernment" ? "usgovernment" : "public"
 }

--- a/infra/providers.tf
+++ b/infra/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.113.0"
+      version = "~> 4.3.0"
     }
     azuread = {
       source  = "hashicorp/azuread"

--- a/scripts/environments/local.env.example
+++ b/scripts/environments/local.env.example
@@ -5,6 +5,7 @@
 # This is set by the Azure Pipeline for other environments.
 export LOCATION="westeurope" # Required
 export WORKSPACE="myworkspace" # Required
+export SUBSCRIPTION_ID="" # Required
 
 # ----------------------------------------------------------
 # The following values determine the features that are enabled in the deployment.

--- a/scripts/load-env.sh
+++ b/scripts/load-env.sh
@@ -105,4 +105,7 @@ export TF_VAR_resource_group_name="infoasst-$WORKSPACE"
 # The default key that is used in the remote state
 export TF_BACKEND_STATE_KEY="shared.infoasst.tfstate"
 
+# Subscription ID mandatory for Terraform AzureRM provider 4.x.x https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/4.0-upgrade-guide#specifying-subscription-id-is-now-mandatory
+export ARM_SUBSCRIPTION_ID="$SUBSCRIPTION_ID"
+
 echo -e "\n\e[32m🎯 Target Resource Group: \e[33m$TF_VAR_resource_group_name\e[0m\n"


### PR DESCRIPTION
This pull request includes multiple changes to the Terraform configuration and environment setup scripts. The primary focus is on updating the Azure provider version, modifying resource configurations, and ensuring compatibility with the new provider version.

### Terraform Configuration Changes:

* **Update Azure Provider Version:**
  - Upgraded `azurerm` provider version from `~> 3.113.0` to `~> 4.3.0` in `infra/providers.tf`.
  - Changed `skip_provider_registration` to `resource_provider_registrations = "none"` in `infra/providers.tf`.

* **Resource Configuration Adjustments:**
  - Modified `azurerm_cognitive_deployment` resource to use `sku` block instead of `scale` block in `infra/core/ai/openaiservices/openaiservices.tf`.
  - Updated `azurerm_storage_account` resource to use `https_traffic_only_enabled` instead of `enable_https_traffic_only` in `infra/core/storage/storage-account.tf`.
  - Changed `module "openaiServices"` to use `sku` block for `chatGptModel` and `azureOpenAIEmbeddingsModel` in `infra/main.tf`. [[1]](diffhunk://#diff-c4edee4039d22cfe2fd0d1ef214e7eba022aa85b29dd5677f4485f60e5b7a668L518-R521) [[2]](diffhunk://#diff-c4edee4039d22cfe2fd0d1ef214e7eba022aa85b29dd5677f4485f60e5b7a668L529-R534)

### Environment Setup Script Changes:

* **Environment Variable Updates:**
  - Added `SUBSCRIPTION_ID` to `scripts/environments/local.env.example` to ensure it is set for local environments.
  - Exported `ARM_SUBSCRIPTION_ID` in `scripts/load-env.sh` to comply with the mandatory subscription ID requirement for Terraform AzureRM provider 4.x.x.
  
 fixes #862