### PR TITLE
Remove AAD stored secrets per policy

### DIFF
--- a/infra/core/aad/entra.tf
+++ b/infra/core/aad/entra.tf
@@ -39,13 +39,6 @@ resource "azuread_application" "aad_mgmt_app" {
   service_management_reference = var.serviceManagementReference
 }
 
-resource "azuread_application_password" "aad_mgmt_app_password" {
-  count           = var.isInAutomation ? 0 : 1
-  application_id  = azuread_application.aad_mgmt_app[0].id
-  display_name    = "infoasst-mgmt"
-  end_date_relative = "${var.password_lifetime * 24}h"
-}
-
 resource "azuread_service_principal" "aad_mgmt_sp" {
   count     = var.isInAutomation ? 0 : 1
   client_id = azuread_application.aad_mgmt_app[0].client_id
@@ -65,9 +58,4 @@ output "azure_ad_mgmt_app_client_id" {
 output "azure_ad_mgmt_sp_id" {
   value       = var.isInAutomation ? var.aadMgmtServicePrincipalId : azuread_service_principal.aad_mgmt_sp[0].id
   description = "Service Principal ID of the Azure AD Management App"
-}
-
-output "azure_ad_mgmt_app_secret" {
-  value       = var.isInAutomation ? var.aadMgmtClientSecret : azuread_application_password.aad_mgmt_app_password[0].value
-  description = "Secret of the Azure AD Management App"
 }

--- a/infra/core/security/keyvault/variables.tf
+++ b/infra/core/security/keyvault/variables.tf
@@ -19,11 +19,6 @@ variable "kvAccessObjectId" {
   type        = string
 }
 
-variable "spClientSecret" {
-  description = "The client secret for the service principal"
-  type        = string
-}
-
 variable "resourceGroupName" {
   type    = string
   default = ""

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -252,7 +252,6 @@ module "kvModule" {
   name                          = "infoasst-kv-${random_string.random.result}"
   location                      = var.location
   kvAccessObjectId              = data.azurerm_client_config.current.object_id 
-  spClientSecret                = module.entraObjects.azure_ad_mgmt_app_secret 
   resourceGroupName             = azurerm_resource_group.rg.name
   tags                          = local.tags
   is_secure_mode                = var.is_secure_mode

--- a/scripts/environments/shared-ia.env
+++ b/scripts/environments/shared-ia.env
@@ -1,6 +1,6 @@
 # Region to deploy into when running locally.
 # This is set by the Azure Pipeline for other environments.
-export LOCATION="westeurope"
+export LOCATION="uksouth"
 export WORKSPACE="shared"
 export SUBSCRIPTION_ID="$ARM_SUBSCRIPTION_ID"
 

--- a/scripts/environments/shared-ia.env
+++ b/scripts/environments/shared-ia.env
@@ -1,6 +1,6 @@
 # Region to deploy into when running locally.
 # This is set by the Azure Pipeline for other environments.
-export LOCATION="eastus"
+export LOCATION="westeurope"
 export WORKSPACE="shared"
 export SUBSCRIPTION_ID="$ARM_SUBSCRIPTION_ID"
 
@@ -59,7 +59,7 @@ export SECRET_EXPIRATION_DAYS=730 # Required
 
 # If using an existing deployment of Azure OpenAI, set the USE_EXISTING_AOAI to true and fill in the following values
 export USE_EXISTING_AOAI=true
-export AZURE_OPENAI_RESOURCE_GROUP="aoai_host"
+export AZURE_OPENAI_RESOURCE_GROUP="openai_host"
 
 export USE_AZURE_OPENAI_EMBEDDINGS=true
 export AZURE_OPENAI_EMBEDDING_DEPLOYMENT_NAME="text-embedding-ada-002"

--- a/scripts/environments/shared-ia.env
+++ b/scripts/environments/shared-ia.env
@@ -90,3 +90,6 @@ export ENABLE_DEV_CODE=false
 export PASSWORD_LIFETIME=365
 
 export ENABLE_DDOS_PROTECTION_PLAN=false
+
+export TF_VAR_enrichmentAppServiceSkuSize="S3"
+export TF_VAR_enrichmentAppServiceSkuTier="Standard"

--- a/scripts/environments/tmp-ia.env
+++ b/scripts/environments/tmp-ia.env
@@ -90,3 +90,6 @@ export ENABLE_DEV_CODE=false
 export PASSWORD_LIFETIME=730
 
 export ENABLE_DDOS_PROTECTION_PLAN=false
+
+export TF_VAR_enrichmentAppServiceSkuSize="S3"
+export TF_VAR_enrichmentAppServiceSkuTier="Standard"

--- a/scripts/environments/tmp-ia.env
+++ b/scripts/environments/tmp-ia.env
@@ -1,6 +1,6 @@
 # Region to deploy into when running locally.
 # This is set by the Azure Pipeline for other environments.
-export LOCATION="westeurope"
+export LOCATION="uksouth"
 export WORKSPACE="tmp$BUILD_BUILDID"
 export SUBSCRIPTION_ID="$ARM_SUBSCRIPTION_ID"
 

--- a/scripts/environments/tmp-ia.env
+++ b/scripts/environments/tmp-ia.env
@@ -1,6 +1,6 @@
 # Region to deploy into when running locally.
 # This is set by the Azure Pipeline for other environments.
-export LOCATION="eastus"
+export LOCATION="westeurope"
 export WORKSPACE="tmp$BUILD_BUILDID"
 export SUBSCRIPTION_ID="$ARM_SUBSCRIPTION_ID"
 
@@ -59,7 +59,7 @@ export SECRET_EXPIRATION_DAYS=730 # Required
 
 # If using an existing deployment of Azure OpenAI, set the USE_EXISTING_AOAI to true and fill in the following values
 export USE_EXISTING_AOAI=true
-export AZURE_OPENAI_RESOURCE_GROUP="aoai_host"
+export AZURE_OPENAI_RESOURCE_GROUP="openai_host"
 
 export USE_AZURE_OPENAI_EMBEDDINGS=true
 export AZURE_OPENAI_EMBEDDING_DEPLOYMENT_NAME="text-embedding-ada-002"
@@ -87,6 +87,6 @@ export CUSTOMER_USAGE_ATTRIBUTION_ID=""
 
 export ENABLE_DEV_CODE=false
 
-export PASSWORD_LIFETIME=365
+export PASSWORD_LIFETIME=730
 
 export ENABLE_DDOS_PROTECTION_PLAN=false


### PR DESCRIPTION
This pull request includes several changes to the Azure AD management infrastructure, primarily focusing on removing the application password resource and its associated outputs and variables.

### Removal of application password resource and associated outputs:

* [`infra/core/aad/entra.tf`](diffhunk://#diff-6be2c0a16802b995024064fb8f1b4c303d8a7a2c03fb1124c9e7fd98016807fdL42-L48): Removed the `azuread_application_password` resource definition for `aad_mgmt_app_password`. This resource was responsible for creating a password for the Azure AD Management App.
* [`infra/core/aad/entra.tf`](diffhunk://#diff-6be2c0a16802b995024064fb8f1b4c303d8a7a2c03fb1124c9e7fd98016807fdL69-L73): Removed the `output "azure_ad_mgmt_app_secret"` which was outputting the secret value of the Azure AD Management App.

### Cleanup of unused variables:

* [`infra/core/security/keyvault/variables.tf`](diffhunk://#diff-46d28e0ce467061b98802067692876b598351de01d824a3e8b1ae59dcdb1f042L22-L26): Removed the `variable "spClientSecret"` which was previously used to store the client secret for the service principal.

### Updates to module inputs:

* [`infra/main.tf`](diffhunk://#diff-c4edee4039d22cfe2fd0d1ef214e7eba022aa85b29dd5677f4485f60e5b7a668L255): Removed the `spClientSecret` input from the `kvModule` module configuration.