### PR TITLE
copilot to agent updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to Information Assistant copilot template
+# Contributing to Information Assistant agent template
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a
 Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Information Assistant (IA) copilot template
+# Information Assistant (IA) agent template
 
 > [!IMPORTANT]  
 > As of November 15, 2023, Azure Cognitive Search has been renamed to Azure AI Search. Azure Cognitive Services have also been renamed to Azure AI Services.
@@ -38,15 +38,15 @@
 
 [![Open in GitHub Codespaces](https://img.shields.io/static/v1?style=for-the-badge&label=GitHub+Codespaces&message=Open&color=brightgreen&logo=github)](https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=601652366&machine=basicLinux32gb&devcontainer_path=.devcontainer%2Fdevcontainer.json&location=eastus)
 
-Information Assistant (IA) copilot template provides a starting point for organizations to build their own custom generative AI capability to extend the power of Azure OpenAI. It showcases a common scenario using large language models (LLMs) to “chat with your own data” through the [Retrieval Augmented Generation (RAG) pattern](https://learn.microsoft.com/azure/search/retrieval-augmented-generation-overview). This pattern lets you use the reasoning abilities of LLMs to generate responses based on your domain data without fine-tuning the model. 
+Information Assistant (IA) agent template provides a starting point for organizations to build their own custom generative AI capability to extend the power of Azure OpenAI. It showcases a common scenario using large language models (LLMs) to “chat with your own data” through the [Retrieval Augmented Generation (RAG) pattern](https://learn.microsoft.com/azure/search/retrieval-augmented-generation-overview). This pattern lets you use the reasoning abilities of LLMs to generate responses based on your domain data without fine-tuning the model. 
 
-Information Assistant copilot template is an end-to-end solution which is a comprehensive reference sample including documentation, source code, and deployment to allow you to take and extend for your own purposes.
+Information Assistant agent template is an end-to-end solution which is a comprehensive reference sample including documentation, source code, and deployment to allow you to take and extend for your own purposes.
 
-This copilot template showcases integration between Azure and OpenAI's LLMs. It leverages Azure AI Search for data retrieval and ChatGPT-style Q&A interactions. Using the RAG design pattern with Azure OpenAI's GPT models, it provides a natural language interaction to discover relevant responses to user queries. Azure AI Search simplifies data ingestion, transformation, indexing, and multilingual translation.
+This agent template showcases integration between Azure and OpenAI's LLMs. It leverages Azure AI Search for data retrieval and ChatGPT-style Q&A interactions. Using the RAG design pattern with Azure OpenAI's GPT models, it provides a natural language interaction to discover relevant responses to user queries. Azure AI Search simplifies data ingestion, transformation, indexing, and multilingual translation.
 
-The copilot adapts prompts based on the model type for enhanced performance. Users can customize settings like temperature and persona for personalized AI interactions. It offers features like explainable thought processes, referenceable citations, and direct content for verification.
+The agent adapts prompts based on the model type for enhanced performance. Users can customize settings like temperature and persona for personalized AI interactions. It offers features like explainable thought processes, referenceable citations, and direct content for verification.
 
-Please [see this video](https://aka.ms/InfoAssist/video) for use cases that may be achievable with Information Assistant copilot template.
+Please [see this video](https://aka.ms/InfoAssist/video) for use cases that may be achievable with Information Assistant agent template.
 
 # Response generation approaches
 
@@ -66,7 +66,7 @@ It generates response by using LLM as a reasoning engine. The key strength lies 
 
 ## Features
 
-The Information Assistant copilot template contains several features, many of which have their own documentation.
+The Information Assistant agent template contains several features, many of which have their own documentation.
 
 - Examples of custom Retrieval Augmented Generation (RAG), Prompt Engineering, and Document Pre-Processing
 - Azure AI Search Integration to include text search of both text documents and images
@@ -115,15 +115,15 @@ For a detailed review see our [Features](./docs/features/features.md) page.
 
 ## Deployment
 
-Please follow the instructions in [the deployment guide](/docs/deployment/deployment.md) to install the Information Assistant copilot template in your Azure subscription.
+Please follow the instructions in [the deployment guide](/docs/deployment/deployment.md) to install the Information Assistant agent template in your Azure subscription.
 
-Once completed, follow the [instructions for using Information Assistant copilot template for the first time](/docs/deployment/using_ia_first_time.md).
+Once completed, follow the [instructions for using Information Assistant agent template for the first time](/docs/deployment/using_ia_first_time.md).
 
 You may choose to **[view the deployment and usage click-through guides](https://aka.ms/InfoAssist/deploy)** to see the steps in action. These videos may be useful to help clarify specific steps or actions in the instructions.
 
 ## Responsible AI
 
-The Information Assistant (IA) copilot template and Microsoft are committed to the advancement of AI driven by ethical principles that put people first.
+The Information Assistant (IA) agent template and Microsoft are committed to the advancement of AI driven by ethical principles that put people first.
 
 ### Transparency Note
 
@@ -151,7 +151,7 @@ The software may collect information about you and your use of the software and 
 
 ### About Data Collection
 
-Data collection by the software in this repository is used by Microsoft solely to help justify the efforts of the teams who build and maintain this copilot template for our customers. It is your choice to leave this enabled, or to disable data collection.
+Data collection by the software in this repository is used by Microsoft solely to help justify the efforts of the teams who build and maintain this agent template for our customers. It is your choice to leave this enabled, or to disable data collection.
 
 Data collection is implemented by the presence of a tracking GUID in the environment variables at deployment time. The GUID is associated with each Azure resource deployed by the installation scripts. This GUID is used by Microsoft to track the Azure consumption this open source solution generates.
 
@@ -177,13 +177,13 @@ docs/deployment/ | Detailed documentation on how to deploy and start using Infor
 docs/features/ | Detailed documentation of specific features and development level configuration for Information Assistant.
 docs/ | Other supporting documentation that is primarily linked to from the other markdown files.
 functions/ | The pipeline of Azure Functions that handle the document extraction and chunking as well as the custom CosmosDB logging.
-infra/ | The Terraform scripts that deploy the entire IA copilot template. The overall copilot template is orchestrated via the `main.tf` file but most of the resource deployments are modularized under the **core** folder.
-pipelines/ | Azure DevOps pipelines that can be used to enable CI/CD deployments of the copilot template.
+infra/ | The Terraform scripts that deploy the entire IA agent template. The overall agent template is orchestrated via the `main.tf` file but most of the resource deployments are modularized under the **core** folder.
+pipelines/ | Azure DevOps pipelines that can be used to enable CI/CD deployments of the agent template.
 scripts/environments/ | Deployment configuration files. This is where all external configuration values will be set.
 scripts/ | Supporting scripts that perform the various deployment tasks such as infrastructure deployment, Azure WebApp and Function deployments, building of the webapp and functions source code, etc. These scripts align to the available commands in the `Makefile`.
 tests/ | Functional Test scripts that are used to validate a deployed Information Assistant's document processing pipelines are working as expected.
 Makefile | Deployment command definitions and configurations. You can use `make help` to get more details on available commands.
-README.md | Starting point for this repo. It covers overviews of the copilot template, Responsible AI, Environment, Deployment, and Usage of the copilot template.
+README.md | Starting point for this repo. It covers overviews of the agent template, Responsible AI, Environment, Deployment, and Usage of the agent template.
 
 ### References
 
@@ -206,7 +206,7 @@ This project may contain trademarks or logos for projects, products, or services
 
 ## Microsoft Legal Notice
 
-**Notice**. The Information Assistant copilot template (the "IA") is PROVIDED "AS-IS," "WITH ALL FAULTS," AND "AS AVAILABLE," AND ARE EXCLUDED FROM THE SERVICE LEVEL AGREEMENTS AND LIMITED WARRANTY. The IA may employ lesser or different privacy and security measures than those typically present in Azure Services. Unless otherwise noted, The IA should not be used to process Personal Data or other data that is subject to legal or regulatory compliance requirements. The following terms in the DPA do not apply to the IA: Processing of Personal Data, GDPR, Data Security, and HIPAA Business Associate. We may change or discontinue the IA at any time without notice. The IA (1) is not designed, intended, or made available as legal services, (2) is not intended to substitute for professional legal counsel or judgment, and (3) should not be used in place of consulting with a qualified professional legal professional for your specific needs. Microsoft makes no warranty that the IA is accurate, up-to-date, or complete. You are wholly responsible for ensuring your own compliance with all applicable laws and regulations. 
+**Notice**. The Information Assistant agent template (the "IA") is PROVIDED "AS-IS," "WITH ALL FAULTS," AND "AS AVAILABLE," AND ARE EXCLUDED FROM THE SERVICE LEVEL AGREEMENTS AND LIMITED WARRANTY. The IA may employ lesser or different privacy and security measures than those typically present in Azure Services. Unless otherwise noted, The IA should not be used to process Personal Data or other data that is subject to legal or regulatory compliance requirements. The following terms in the DPA do not apply to the IA: Processing of Personal Data, GDPR, Data Security, and HIPAA Business Associate. We may change or discontinue the IA at any time without notice. The IA (1) is not designed, intended, or made available as legal services, (2) is not intended to substitute for professional legal counsel or judgment, and (3) should not be used in place of consulting with a qualified professional legal professional for your specific needs. Microsoft makes no warranty that the IA is accurate, up-to-date, or complete. You are wholly responsible for ensuring your own compliance with all applicable laws and regulations. 
 
 ## Code of Conduct
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -10,7 +10,7 @@ Please provide as much information as possible when filing an issue (please reda
 
 For help and questions about using this project, please use the [Discussion](https://github.com/microsoft/PubSec-Info-Assistant/discussions) forums on our GitHub repo page.
 
-For customer support deploying Information Assistant copilot template, please reach out to your local Microsoft representative or email the [Public Sector Industries & Regulated Products Accelerators Team](mailto:isat-support@microsoft.com).
+For customer support deploying Information Assistant agent template, please reach out to your local Microsoft representative or email the [Public Sector Industries & Regulated Products Accelerators Team](mailto:isat-support@microsoft.com).
 
 ## Providing feedback
 

--- a/app/frontend/index.html
+++ b/app/frontend/index.html
@@ -7,7 +7,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Information Assistant copilot template</title>
+    <title>Information Assistant agent template</title>
   </head>
   <body>
     <div id="root"></div>

--- a/app/frontend/src/pages/content/Content.tsx
+++ b/app/frontend/src/pages/content/Content.tsx
@@ -48,7 +48,7 @@ const Content = () => {
                             <SparkleFilled fontSize={"60px"} primaryFill={"rgba(115, 118, 225, 1)"} aria-hidden="true" aria-label="Supported File Types" />
                             <h1 className={styles.EmptyStateTitle}>Supported file types</h1>
                             <span className={styles.EmptyObjectives}>
-                                The Information Assistant copilot template currently supports the following file types:
+                                The Information Assistant agent template currently supports the following file types:
                             </span>
                             <span className={styles.EmptyObjectivesList}>
                                 <span className={styles.EmptyObjectivesListItem}>

--- a/docs/costestimator.md
+++ b/docs/costestimator.md
@@ -1,14 +1,14 @@
-# Information Assistant (IA) copilot template - Estimation
+# Information Assistant (IA) agent template - Estimation
 
-The Azure pricing calculator helps estimate costs by considering the amount of data to be processed and stored, as well as the expected performance level. It allows users to customize and combine different Azure services for Information Assistant copilot template, version 1.2, and provides cost estimates based on the chosen configurations.
+The Azure pricing calculator helps estimate costs by considering the amount of data to be processed and stored, as well as the expected performance level. It allows users to customize and combine different Azure services for Information Assistant agent template, version 1.2, and provides cost estimates based on the chosen configurations.
 
 | Solution            | Environment  |    Azure Pricing Calculator Link                                          |
 | :------------------:|:-----------------------------:|:------------------------------------------------:|
-| IA copilot template, version 1.2 | Sandbox  |  [Sample Azure Estimation](https://azure.com/e/bd6e516bb0b549abb6d39cce088af684) |
+| IA agent template, version 1.2 | Sandbox  |  [Sample Azure Estimation](https://azure.com/e/bd6e516bb0b549abb6d39cce088af684) |
 
 ## Azure Services
 
-The following list of Azure Services will be deployed for IA copilot template, version 1.2:
+The following list of Azure Services will be deployed for IA agent template, version 1.2:
 
 - App Service (App Service Plan) [:link:](https://azure.microsoft.com/en-ca/pricing/details/app-service/linux/)
 - Application Insights [:link:](https://azure.microsoft.com/en-ca/pricing/details/monitor/)

--- a/docs/deployment/accepting_responsible_ai_notice.md
+++ b/docs/deployment/accepting_responsible_ai_notice.md
@@ -1,6 +1,6 @@
 # Accepting Azure AI Service Responsible AI Notice
 
-To be able to install the Information Assistant copilot template, you must have manually accepted the Azure AI Services Responsible AI Notice once for your subscription. To do this follow these steps:
+To be able to install the Information Assistant agent template, you must have manually accepted the Azure AI Services Responsible AI Notice once for your subscription. To do this follow these steps:
 
 ## Manually create an "Azure AI services" in your Azure subscription and accept "Responsible AI Notice"
 

--- a/docs/deployment/accepting_responsible_ai_notice_multi_service.md
+++ b/docs/deployment/accepting_responsible_ai_notice_multi_service.md
@@ -1,6 +1,6 @@
 # Accepting Azure AI Services Multi-service Account Responsible AI Notice
 
-To be able to install the Information Assistant copilot template, you must have manually accepted the Azure AI Services Multi-service Account Responsible AI Notice once for your subscription. To do this follow these steps:
+To be able to install the Information Assistant agent template, you must have manually accepted the Azure AI Services Multi-service Account Responsible AI Notice once for your subscription. To do this follow these steps:
 
 ## Manually create an "Azure AI Services Multi-service Account" in your Azure subscription and accept "Responsible AI Notice"
 

--- a/docs/deployment/configure_local_dev_environment.md
+++ b/docs/deployment/configure_local_dev_environment.md
@@ -88,7 +88,7 @@ In your Ubuntu 22.04(WSL) terminal from the previous step, follow the directions
 
 ## Configure Local Development Environment
 
-Follow these steps to get the copilot template up and running in a subscription of your choice.
+Follow these steps to get the agent template up and running in a subscription of your choice.
 
 ### Clone Repo
 

--- a/docs/deployment/considerations_production.md
+++ b/docs/deployment/considerations_production.md
@@ -1,6 +1,6 @@
 # Considerations For Adopting Into Production
 
-This documentation highlights key considerations for transitioning from an Information Assistant (IA) copilot template to a production-ready deployment. Emphasizing scalability, high availability, security, and proactive management, the recommendations cover components such as App Server scaling, Load Balancing strategies, and global-scale content delivery. Additional guidance addresses GPT Model throttling, security enhancements, proactive monitoring, and redundancy. It stresses the importance of safeguarding against cyber threats, seamless integration with existing ecosystems, and proactive environment management through monitoring and alerts.
+This documentation highlights key considerations for transitioning from an Information Assistant (IA) agent template to a production-ready deployment. Emphasizing scalability, high availability, security, and proactive management, the recommendations cover components such as App Server scaling, Load Balancing strategies, and global-scale content delivery. Additional guidance addresses GPT Model throttling, security enhancements, proactive monitoring, and redundancy. It stresses the importance of safeguarding against cyber threats, seamless integration with existing ecosystems, and proactive environment management through monitoring and alerts.
 
 ## Scalability and High Availability
 
@@ -82,7 +82,7 @@ Diagnostic settings have been enabled in IA as part of our secure mode. You can 
 
 ## Document Ingestion Limitations
 
-**Consideration:** This copilot template uses Azure Document Intelligence for PDF's and Unstructured.io for document processing. These tools have their own limitations when it comes to document sizes they can handle. The page limit and document size limits for PDFs on Document Intelligence can vary by subscription tier. Learn more about Document Intelligence [here](https://learn.microsoft.com/en-us/legal/cognitive-services/document-intelligence/characteristics-and-limitations).
+**Consideration:** This agent template uses Azure Document Intelligence for PDF's and Unstructured.io for document processing. These tools have their own limitations when it comes to document sizes they can handle. The page limit and document size limits for PDFs on Document Intelligence can vary by subscription tier. Learn more about Document Intelligence [here](https://learn.microsoft.com/en-us/legal/cognitive-services/document-intelligence/characteristics-and-limitations).
 
 More info on unstructured.io for other supported document types can be found [here](https://unstructured-io.github.io/unstructured/introduction.html).
 
@@ -107,4 +107,4 @@ This can be achieved by modifying the currently provided UI by making a couple o
 
 ## In Summary
 
- Ensure that your IA copilot template seamlessly integrates into your existing ecosystem, considering compatibility and interoperability. Use the IA copilot template as a blueprint to plan integration into your ecosystem.
+ Ensure that your IA agent template seamlessly integrates into your existing ecosystem, considering compatibility and interoperability. Use the IA agent template as a blueprint to plan integration into your ecosystem.

--- a/docs/deployment/deployment.md
+++ b/docs/deployment/deployment.md
@@ -1,14 +1,14 @@
-# Deploying Information Assistant (IA) copilot template to Azure
+# Deploying Information Assistant (IA) agent template to Azure
 
 :warning: **IMPORTANT**: Please ensure you have met the [Azure account requirements](../../README.md#azure-account-requirements) before continuing.
 
-Follow these steps to get the copilot template up and running in a subscription of your choice. Note that there may be specific instructions for deploying to Azure Government or other Sovereign regions.
+Follow these steps to get the agent template up and running in a subscription of your choice. Note that there may be specific instructions for deploying to Azure Government or other Sovereign regions.
 
-If you prefer to have a more guided experience, you may choose to [view the click-through deployment guide](https://aka.ms/InfoAssist/deploy) for this copilot template.  
+If you prefer to have a more guided experience, you may choose to [view the click-through deployment guide](https://aka.ms/InfoAssist/deploy) for this agent template.  
 
 ## Development Environment Configuration
 
-The deployment process for the IA copilot template, uses a concept of **Developing inside a Container** to containerize all the necessary pre-requisite component without requiring them to be installed on the local machine. The environment you will work in will be created using a development container or dev container hosted on a virtual machine using GitHub Codespaces.
+The deployment process for the IA agent template, uses a concept of **Developing inside a Container** to containerize all the necessary pre-requisite component without requiring them to be installed on the local machine. The environment you will work in will be created using a development container or dev container hosted on a virtual machine using GitHub Codespaces.
 
 Begin by first forking the Information Assistant repository into your own repository. This can be useful for managing any changes you may require for your local environment. It will also enable you to accept and merge changes from the Information Assistant repo as future releases and hotfixes are made available.
 
@@ -27,7 +27,7 @@ Once you have completed setting up a GitHub Codespaces, please move on to the Si
 
 ## Sizing estimator
 
- The IA copilot template needs to be sized appropriately based on your use case. Please review our [Sizing Estimator](/docs/costestimator.md) to help find the configuration that fits your needs.
+ The IA agent template needs to be sized appropriately based on your use case. Please review our [Sizing Estimator](/docs/costestimator.md) to help find the configuration that fits your needs.
 
  To change the size of components deployed, make changes in the [Terraform Variables](/infra/variables.tf) file.
 
@@ -247,14 +247,14 @@ Once deployed, you can find the URL of your installation by:
 
 ## Next steps
 
-At this point deployment is complete. Please go to the [Using the IA copilot template for the first time](/docs/deployment/using_ia_first_time.md) section and complete the following steps.
+At this point deployment is complete. Please go to the [Using the IA agent template for the first time](/docs/deployment/using_ia_first_time.md) section and complete the following steps.
 
 ## Additional Considerations for a Production Adoption
 
-There are considerations for adopting the Information Assistant (IA) copilot template into a production environment. [See this documentation](/docs/deployment/considerations_production.md).
+There are considerations for adopting the Information Assistant (IA) agent template into a production environment. [See this documentation](/docs/deployment/considerations_production.md).
 
 ## Need Help?
 
 Check these [troubleshooting methods](/docs/deployment/troubleshooting.md).
 
-If you need assistance with deployment or configuration of this copilot template, please leverage the Discussion forum in this repository, or reach out to your Microsoft Unified Support account manager.
+If you need assistance with deployment or configuration of this agent template, please leverage the Discussion forum in this repository, or reach out to your Microsoft Unified Support account manager.

--- a/docs/deployment/setting_up_sandbox_environment.md
+++ b/docs/deployment/setting_up_sandbox_environment.md
@@ -1,6 +1,6 @@
 # Setting up Azure DevOps Pipeline for deploying Sandbox Environment
 
-The process of setting up a CI/CD pipeline for the Information Assistant copilot template requires the use of Azure DevOps to host and run the pipeline and deployment environment.
+The process of setting up a CI/CD pipeline for the Information Assistant agent template requires the use of Azure DevOps to host and run the pipeline and deployment environment.
 
 An example process involves:
 

--- a/docs/deployment/using_ia_first_time.md
+++ b/docs/deployment/using_ia_first_time.md
@@ -1,8 +1,8 @@
-# Using IA copilot template for the first time
+# Using IA agent template for the first time
 
-Once you have successfully deployed the IA copilot template, you are ready to use the copilot template to process some data.
+Once you have successfully deployed the IA agent template, you are ready to use the agent template to process some data.
 
-To use the IA copilot template, you need to follow these steps:
+To use the IA agent template, you need to follow these steps:
 
 > 1. Prepare your data and upload it to Azure.
 >

--- a/docs/features/architectural_decisions.md
+++ b/docs/features/architectural_decisions.md
@@ -1,6 +1,6 @@
-# Enhancing IA copilot template: Architectural Decisions
+# Enhancing IA agent template: Architectural Decisions
 
-We've focused our architectural decisions on the unique requirements of IA copilot template for Public Sector customers. Our exploration and investigation efforts have been tailored to address the specific nuances of this use case. We've investigated the merits of different approaches across our solution, ensuring our architectural decisions are not just informed but fine-tuned for the unique demands of public sector customers. our findings and decisions may not be applicable to all Generative AI use cases.
+We've focused our architectural decisions on the unique requirements of IA agent template for Public Sector customers. Our exploration and investigation efforts have been tailored to address the specific nuances of this use case. We've investigated the merits of different approaches across our solution, ensuring our architectural decisions are not just informed but fine-tuned for the unique demands of public sector customers. our findings and decisions may not be applicable to all Generative AI use cases.
 
 ## Document Processing
 

--- a/docs/features/configuring_language_env_files.md
+++ b/docs/features/configuring_language_env_files.md
@@ -1,10 +1,10 @@
 # Configuring your own language ENV file
 
-Within the IA copilot template you can customize the language settings of the search index, search skillsets, and Azure OpenAI prompts. To do this you must create a language ENV file in the `scripts/environments/languages` folder. This documentation will explain how to set up your own language file.
+Within the IA agent template you can customize the language settings of the search index, search skillsets, and Azure OpenAI prompts. To do this you must create a language ENV file in the `scripts/environments/languages` folder. This documentation will explain how to set up your own language file.
 
 ## Mapping to your custom language ENV file for deployment
 
-The first step in configuring a language for the IA copilot template is to create a new language ENV file in the `scripts/environments/languages` folder. Simply add a new file in this folder and remember the name of the file you create. In this example, we have created a language ENV file for the Greek language (`el.env`).
+The first step in configuring a language for the IA agent template is to create a new language ENV file in the `scripts/environments/languages` folder. Simply add a new file in this folder and remember the name of the file you create. In this example, we have created a language ENV file for the Greek language (`el.env`).
 
 ![Example language file for Greek language](../images/custom_language_file.png)
 

--- a/docs/features/enable_customer_usage_attribution.md
+++ b/docs/features/enable_customer_usage_attribution.md
@@ -1,6 +1,6 @@
 # Customer Usage Attribution
 
-Customer usage attribution associates usage from Azure resources in customer subscriptions created while deploying your IP with you as a partner. Forming these associations in internal Microsoft systems brings greater visibility to the Azure footprint running the Information Assistant copilot template.
+Customer usage attribution associates usage from Azure resources in customer subscriptions created while deploying your IP with you as a partner. Forming these associations in internal Microsoft systems brings greater visibility to the Azure footprint running the Information Assistant agent template.
 
 ## Enable Customer Usage Attribution
 

--- a/docs/features/features.md
+++ b/docs/features/features.md
@@ -1,6 +1,6 @@
-# Information Assistant (IA) copilot template features
+# Information Assistant (IA) agent template features
 
-Please see below sections for coverage of IA copilot template features.
+Please see below sections for coverage of IA agent template features.
 
 * [Retrieval Augmented Generation (RAG)](/docs/features/features.md#retrieval-augmented-generation-rag)
 * [Prompt Engineering](/docs/features/features.md#prompt-engineering)
@@ -55,7 +55,7 @@ Images | jpg, jpeg, png, gif, bmp, tif, tiff
 * creating a standard JSON representation of all a documents text-based content
 * chunking and saving metadata into manageable sizes to be used in the RAG pattern
 
-The Information Assistant copilot template [pre-processes](/docs/features/document_pre_processing.md) certain document types to allow better understanding of large complex documents.
+The Information Assistant agent template [pre-processes](/docs/features/document_pre_processing.md) certain document types to allow better understanding of large complex documents.
 
 We also log the status of the pre-processing in Azure Cosmos DB. View our [Status Logging](/functions/shared_code/status_log.md) page for more details.
 
@@ -89,7 +89,7 @@ Image Search is only available in regions that support dense captions. For a ful
 
 ## Azure AI Search Integration
 
-This copilot template employs Vector Hybrid Search which combines vector similarity with keyword matching to enhance search accuracy. This approach empowers you to find relevant information efficiently by combining the strengths of both semantic vectors and keywords.
+This agent template employs Vector Hybrid Search which combines vector similarity with keyword matching to enhance search accuracy. This approach empowers you to find relevant information efficiently by combining the strengths of both semantic vectors and keywords.
 
 To learn more, please visit the [Cognitive Search](/docs/features/cognitive_search.md) feature page.
 
@@ -111,7 +111,7 @@ Do not use this code with untrusted inputs, with elevated permissions, or withou
 
 ## Enhanced AI Interaction
 
-**Simple File Upload and Status:** We have put uploading of files into the copilot template in the hands of the users by providing a simple drag-and-drop user interface for adding new content and a status page for monitoring document pre-processing.
+**Simple File Upload and Status:** We have put uploading of files into the agent template in the hands of the users by providing a simple drag-and-drop user interface for adding new content and a status page for monitoring document pre-processing.
 
 **Visualizing Thought Process:** Gain insights into the AI's decision-making process by visualizing how it arrives at answers, providing transparency and control.
 
@@ -125,11 +125,11 @@ Do not use this code with untrusted inputs, with elevated permissions, or withou
 
 ![Chat screen](/docs/images/info-assist-chat-ui.png)
 
-The end user leverages the web interface as the primary method to engage with the IA copilot template, and the Azure OpenAI service. The user interface is very similar to that of the OpenAI ChatGPT interface, though it provides different and additional functionality which is outlined on the [User Experience](/docs/features/user_experience.md) page.
+The end user leverages the web interface as the primary method to engage with the IA agent template, and the Azure OpenAI service. The user interface is very similar to that of the OpenAI ChatGPT interface, though it provides different and additional functionality which is outlined on the [User Experience](/docs/features/user_experience.md) page.
 
 ## Document Deletion
 
-There are multiple options to for deleting documents in the IA copilot template. Most users will perform document deletion in the UI, while experience technical users may opt for deleting files through the underlying infrastructure. Document deletions are not instantaneous and can take up to ten minutes to propagate through all components of the system.
+There are multiple options to for deleting documents in the IA agent template. Most users will perform document deletion in the UI, while experience technical users may opt for deleting files through the underlying infrastructure. Document deletions are not instantaneous and can take up to ten minutes to propagate through all components of the system.
 
 ### File Deletion in the UI
 

--- a/docs/features/optional_features.md
+++ b/docs/features/optional_features.md
@@ -1,6 +1,6 @@
-# Information Assistant (IA) copilot template optional features
+# Information Assistant (IA) agent template optional features
 
-Please see below sections for coverage of IA copilot template optional features.
+Please see below sections for coverage of IA agent template optional features.
 
 * [Configuring your own language ENV file](#configuring-your-own-language-env-file)
 * [Debugging functions](#debugging-functions)
@@ -15,7 +15,7 @@ Please see below sections for coverage of IA copilot template optional features.
 
 ## Configuring your own language ENV file
 
-At deployment time, you can alter the behavior of the IA copilot template to use a language of your choosing across it's Azure AI Search and Azure OpenAI prompting. See [Configuring your own language ENV file](/docs/features/configuring_language_env_files.md) more information.
+At deployment time, you can alter the behavior of the IA agent template to use a language of your choosing across it's Azure AI Search and Azure OpenAI prompting. See [Configuring your own language ENV file](/docs/features/configuring_language_env_files.md) more information.
 
 ## Debugging functions
 
@@ -35,7 +35,7 @@ Setting up a pipeline to deploy a new Sandbox environment requires some manual c
 
 ## Customer Usage Attribution
 
-A feature offered within Azure, "Customer Usage Attribution" associates usage from Azure resources in customer subscriptions created while deploying your IP with you as a partner. Forming these associations in internal Microsoft systems brings greater visibility to the Azure footprint running the Information Assistant copilot template.
+A feature offered within Azure, "Customer Usage Attribution" associates usage from Azure resources in customer subscriptions created while deploying your IP with you as a partner. Forming these associations in internal Microsoft systems brings greater visibility to the Azure footprint running the Information Assistant agent template.
 
 Check out how to [enable Customer Usage Attribution](/docs/features/enable_customer_usage_attribution.md)
 

--- a/docs/features/user_experience.md
+++ b/docs/features/user_experience.md
@@ -1,6 +1,6 @@
 # User Experience
 
-The end user leverages the web interface as the primary method to engage with the Information Assistant (IA) copilot template, and the Azure OpenAI service. The user interface is very similar to that of the OpenAI ChatGPT interface, though it provides different and additional functionality which is outlined below.
+The end user leverages the web interface as the primary method to engage with the Information Assistant (IA) agent template, and the Azure OpenAI service. The user interface is very similar to that of the OpenAI ChatGPT interface, though it provides different and additional functionality which is outlined below.
 
 ## Having a conversation with your data
 
@@ -10,7 +10,7 @@ When you use the "Chat" capabilities, the system maintains a history for your co
 
 > ![Chat Link](/docs/images/info-assist-chat-ui.png)
 
-There are new modes that extend the Information Assistant user experience. Similar to COPILOT, Information Assistant has a Work and a Web Mode called Work Only and Work + Web respectfully. There is also a Generative mode enabling user interaction with the LLM without grounding the response in their data.
+There are new modes that extend the Information Assistant user experience. Similar to Copilot, Information Assistant has a Work and a Web Mode called Work Only and Work + Web respectfully. There is also a Generative mode enabling user interaction with the LLM without grounding the response in their data.
 
 ## Work Only
 
@@ -113,7 +113,7 @@ Once a file has been uploaded the user can select an example query or enter thie
 
 ## Manage Content
 
-When you engage with IA copilot template in the "Manage Content" method, the system allows you to add new content and see the status of processing for content previously loaded into the IA copilot template.
+When you engage with IA agent template in the "Manage Content" method, the system allows you to add new content and see the status of processing for content previously loaded into the IA agent template.
 
 > You may activate the Manage Content engagement pattern by choosing the "Manage Content" link at the top of the page
 > ![Manage Content Link](/docs/images/manage-content-ui.png)

--- a/docs/function_debug.md
+++ b/docs/function_debug.md
@@ -1,5 +1,5 @@
 # Debugging the Azure Functions Locally in VSCode
-If you wish to debug any of the functions that are part of this copilot template, you can do this locally in VSCode and step through the logic. To do this you will need create a virtual environment. When you open your dev container, you will see a prompt notification in the bottom right of the VS Code window that will do this automatically for you. Click the 'Create virtual environment' button.
+If you wish to debug any of the functions that are part of this agent template, you can do this locally in VSCode and step through the logic. To do this you will need create a virtual environment. When you open your dev container, you will see a prompt notification in the bottom right of the VS Code window that will do this automatically for you. Click the 'Create virtual environment' button.
 
 ![Process Flow](images/virtual_env.jpg)
 

--- a/docs/knownissues.md
+++ b/docs/knownissues.md
@@ -1,6 +1,6 @@
 # Known Issues
 
-Here are some commonly encountered issues when deploying the  Information Assistant copilot template.
+Here are some commonly encountered issues when deploying the  Information Assistant agent template.
 
 ## This subscription cannot create AzureAIServices until you agree to Responsible AI terms for this resource
 
@@ -57,7 +57,7 @@ Turn off the option to require membership for the Azure Active Directory Enterpr
 
 ## Errors due to throttling or overloading Form Recognizer
 
-Occasionally you will see a 429 return code in the FileFormRecSubmissionPDF which indicates that you need to retry your submission later or an internal error was returned by AI Document Intelligence in the FileFormRecPollingPDF function. This indicates the service has encountered internal capacity issues. Both of these situations will occur under heavy load, but the copilot template is designed to back off and retry at a later time, up to a maximum set of retries, which is configurable.
+Occasionally you will see a 429 return code in the FileFormRecSubmissionPDF which indicates that you need to retry your submission later or an internal error was returned by AI Document Intelligence in the FileFormRecPollingPDF function. This indicates the service has encountered internal capacity issues. Both of these situations will occur under heavy load, but the agent template is designed to back off and retry at a later time, up to a maximum set of retries, which is configurable.
 
 ### Solution
 

--- a/docs/secure_deployment/secure_costestimator.md
+++ b/docs/secure_deployment/secure_costestimator.md
@@ -1,16 +1,16 @@
-# Information Assistant (IA) copilot template Secure Mode - Estimation
+# Information Assistant (IA) agent template Secure Mode - Estimation
 
-The Azure pricing calculator helps estimate costs by considering the amount of data to be processed and stored, as well as the expected performance level. It allows users to customize and combine different Azure services for IA copilot template secure mode and provides cost estimates based on the chosen configurations.
+The Azure pricing calculator helps estimate costs by considering the amount of data to be processed and stored, as well as the expected performance level. It allows users to customize and combine different Azure services for IA agent template secure mode and provides cost estimates based on the chosen configurations.
 
 | Solution            | Mode | Environment  |    Azure Pricing Calculator Link  |
 | :------------------:|:---------:|:---------------:|:-------------------:|
-| IA copilot template, version 1.2 | Secure | Sandbox  |  [Sample Azure Estimation](https://azure.com/e/192838582a644d02bd03bd07da650517) |
+| IA agent template, version 1.2 | Secure | Sandbox  |  [Sample Azure Estimation](https://azure.com/e/192838582a644d02bd03bd07da650517) |
 
 ---
 
 ## Azure Services
 
-The following list of Azure Services will be deployed for IA copilot template secure mode:
+The following list of Azure Services will be deployed for IA agent template secure mode:
 
 - App Service (App Service Plan) [:link:](https://azure.microsoft.com/en-ca/pricing/details/app-service/linux/)
 - Application Insights [:link:](https://azure.microsoft.com/en-ca/pricing/details/monitor/)

--- a/docs/secure_deployment/secure_deployment.md
+++ b/docs/secure_deployment/secure_deployment.md
@@ -176,7 +176,7 @@ See [Virtual network and subnet CIDRs](#network-and-subnet-cidr-configuration) s
 
 ## Sizing estimator
 
-The IA copilot template secure mode needs to be sized appropriately based on your use case. Please review our [sizing estimator](/docs/secure_deployment/secure_costestimator.md) to help find the configuration that fits your needs.
+The IA agent template secure mode needs to be sized appropriately based on your use case. Please review our [sizing estimator](/docs/secure_deployment/secure_costestimator.md) to help find the configuration that fits your needs.
 
 To change the size of components deployed, make changes in the [Terraform Variables](/infra/variables.tf) file.
 
@@ -322,7 +322,7 @@ To perform a secure mode deployment, follow these steps:
 21. You should now be able to verify you can resolve the private IP of the Information Assistant. `nslookup` is installed in the Codespace for this use.
 22. Now answer `y` to the connectivity prompt and let the deployment complete. If your deployment has stopped, you can simply run `make deploy` again to get back to the connectivity prompt.
 
-Once deployed only the Azure App Service named like, *infoasst-web-xxxxx*, will be accessible without the VPN established. You can share the URL of the website with users to start using the Information Assistant copilot template.
+Once deployed only the Azure App Service named like, *infoasst-web-xxxxx*, will be accessible without the VPN established. You can share the URL of the website with users to start using the Information Assistant agent template.
 
 ## Additional considerations for secure mode deployment
 
@@ -379,7 +379,7 @@ and the reciprocal setting of:
 
 * Enable '*infoasst-vnet-xxxxx*' to use '*my VPN virtual network's*' remote gateway or route server
 
-This will ensure that the Azure DNS private resolver set up by the Information Assistant copilot template can resolve traffic properly to your VPN connection.
+This will ensure that the Azure DNS private resolver set up by the Information Assistant agent template can resolve traffic properly to your VPN connection.
 
 ### Deploying with Microsoft Cloud for Sovereignty
 
@@ -388,7 +388,7 @@ The [Sovereign Landing Zone (SLZ)](https://aka.ms/slz) is a [Microsoft Cloud for
 For a detailed overview of an SLZ and all its capabilities, see [Sovereign Landing Zone](https://github.com/Azure/sovereign-landing-zone) documentation on GitHub. Also, [review the sample reference architecutre and guidance for deploying LLMs and Azure OpenAI in Retrieval Augmented Generation (RAG) pattern for implementations with the SLZ](https://learn.microsoft.com/industry/sovereignty/architecture/AIwithLLM/overview-ai-llm-configuration).
 
 
-Information Assistant copilot template is compatible with the *Online* management group scope. Within a SLZ deployment, you can find an established Connectivity management group where an existing virtual network and infrastructure already exist.
+Information Assistant agent template is compatible with the *Online* management group scope. Within a SLZ deployment, you can find an established Connectivity management group where an existing virtual network and infrastructure already exist.
 
 >We recommend that connectivity to Information Assistant in the *Online* management group be made accessible by peering the Information Assistant virtual network with the existing virtual network within the SLZ Connectivity management group.
 

--- a/docs/transparency.md
+++ b/docs/transparency.md
@@ -1,6 +1,6 @@
 
 <!-- TOC ignore:true -->
-# Transparency Note: Information Assistant (IA) copilot template
+# Transparency Note: Information Assistant (IA) agent template
 
 Updated 25 Mar 2024
 
@@ -9,7 +9,7 @@ Updated 25 Mar 2024
 <!-- TOC -->
 
 - [What is a Transparency Note?](#what-is-a-transparency-note)
-- [The basics of IA copilot template](#the-basics-of-ia-copilot-template)
+- [The basics of IA agent template](#the-basics-of-ia-agent-template)
     - [Introduction](#introduction)
     - [Key Terms](#key-terms)
 - [Capabilities](#capabilities)
@@ -37,7 +37,7 @@ Updated 25 Mar 2024
     - [Considerations when choosing a use case](#considerations-when-choosing-a-use-case)
         - [Identity Applications](#identity-applications)
         - [Age Appropriateness/Exposure to Minors](#age-appropriatenessexposure-to-minors)
-- [Limitations of IA copilot template](#limitations-of-ia-copilot-template)
+- [Limitations of IA agent template](#limitations-of-ia-agent-template)
     - [Qualitative limitations, human oversight requirements](#qualitative-limitations-human-oversight-requirements)
         - [Confidence Scoring](#confidence-scoring)
         - [Accuracy](#accuracy)
@@ -48,15 +48,15 @@ Updated 25 Mar 2024
 - [System performance](#system-performance)
     - [Grounded experiences](#grounded-experiences)
     - [Ungrounded experiences](#ungrounded-experiences)
-- [Evaluation of IA copilot template](#evaluation-of-ia-copilot-template)
-    - [Evaluating and Integrating IA copilot template for your use](#evaluating-and-integrating-ia-copilot-template-for-your-use)
+- [Evaluation of IA agent template](#evaluation-of-ia-agent-template)
+    - [Evaluating and Integrating IA agent template for your use](#evaluating-and-integrating-ia-agent-template-for-your-use)
         - [Human-in-the-loop](#human-in-the-loop)
         - [Data Quality Evaluation](#data-quality-evaluation)
         - [Evaluation of system performance](#evaluation-of-system-performance)
         - [Use technical documentation](#use-technical-documentation)
 - [Technical limitations, operational factors and ranges](#technical-limitations-operational-factors-and-ranges)
 - [Learn more about responsible AI](#learn-more-about-responsible-ai)
-- [Learn more about the IA copilot template](#learn-more-about-the-ia-copilot-template)
+- [Learn more about the IA agent template](#learn-more-about-the-ia-agent-template)
 - [Contact us](#contact-us)
     - [About this document](#about-this-document)
 
@@ -67,15 +67,15 @@ An AI system includes not only the technology, but also the people who will use 
 
 Microsoft’s Transparency Notes are part of a broader effort at Microsoft to put our AI Principles into practice. To find out more, see the [Microsoft AI principles](https://www.microsoft.com/ai/responsible-ai).
 
-# The basics of IA copilot template
+# The basics of IA agent template
 
 ## Introduction
 
-The IA copilot template is a system built on top of Azure OpenAI service, Azure AI Search and other Azure services. This system showcases capabilites possible with the emerging technologies related to Generative AI and how they may be applied for specific functionality. This copilot template has been designed with Public Sector applications in mind, but has been found to be applicable to additional industries and applications. The user should be aware that Microsoft has evaluated this copilot template for a limited set of use cases. Use cases outside of those which have been evaluated need to be considered and evaluated by those using this copilot template for their intended use cases. 
+The IA agent template is a system built on top of Azure OpenAI service, Azure AI Search and other Azure services. This system showcases capabilites possible with the emerging technologies related to Generative AI and how they may be applied for specific functionality. This agent template has been designed with Public Sector applications in mind, but has been found to be applicable to additional industries and applications. The user should be aware that Microsoft has evaluated this agent template for a limited set of use cases. Use cases outside of those which have been evaluated need to be considered and evaluated by those using this agent template for their intended use cases. 
 
-At its core, the IA copilot template is an implementation of the [Retrieval Augmented Generation (RAG) pattern](https://learn.microsoft.com/en-us/azure/search/retrieval-augmented-generation-overview) and is intended to create a system that allows the end user to ‘have an accurate conversation’ with their data. By uploading supported document types the system makes the data available to the Azure OpenAI service to support a conversational engagement with the data. The system aims to allow the end user to have some controls over how Azure OpenAI service responds, understand how the response was generated (transparency), and verify the response with citations to the specific data the copilot template is referencing.
+At its core, the IA agent template is an implementation of the [Retrieval Augmented Generation (RAG) pattern](https://learn.microsoft.com/en-us/azure/search/retrieval-augmented-generation-overview) and is intended to create a system that allows the end user to ‘have an accurate conversation’ with their data. By uploading supported document types the system makes the data available to the Azure OpenAI service to support a conversational engagement with the data. The system aims to allow the end user to have some controls over how Azure OpenAI service responds, understand how the response was generated (transparency), and verify the response with citations to the specific data the agent template is referencing.
 
-The 1.1 release of the IA copilot template introduces new technologies and use cases on top of the original scope which are covered in this updated Transparency Note. Become familiar with these new system capabilities and use cases to understand their responsible application to your intended use cases before proceeding. This release adds in Bing Web Search API for LLM results to enable grounding via content from the Internet, support for SharePoint as a document source, ability to interact directly with LLMs for purely generative capabilities (ungrounded), and preview agent-based features enabled through the use of [LangChain](https://www.langchain.com/) toolkit. 
+The 1.1 release of the IA agent template introduces new technologies and use cases on top of the original scope which are covered in this updated Transparency Note. Become familiar with these new system capabilities and use cases to understand their responsible application to your intended use cases before proceeding. This release adds in Bing Web Search API for LLM results to enable grounding via content from the Internet, support for SharePoint as a document source, ability to interact directly with LLMs for purely generative capabilities (ungrounded), and preview agent-based features enabled through the use of [LangChain](https://www.langchain.com/) toolkit. 
 
 The system aims to provide the functionality mentioned above while also focusing on the following key areas:
 
@@ -140,7 +140,7 @@ This system is primarily tuned for accuracy of response based on the data provid
 ### Overview
 This capability is implemented with [Bing Web Search for LLMs API](https://www.microsoft.com/en-us/bing/apis/llm) (Bing Web Search) and Azure OpenAI service. The system allows the end user to ask questions in natural language via the Azure OpenAI service, and grounds the answer via responses to the question from Bing Web Search. This allows end users to "have a conversation" with data from recent information found on the public Internet. The system cites the web sites from which it generates answers, allowing the end user to verify the results for accuracy. This system does not use Bing "Answers" which are curated facts available through the Bing web interface and potentially other non-LLM APIs. 
 
-This system behavior is similar to Copilot in Bing. We suggest reviewing their [Transparency Note](https://support.microsoft.com/en-us/topic/copilot-in-bing-our-approach-to-responsible-ai-45b5eae8-7466-43e1-ae98-b48f8ff8fd44) as well when considering if you want to deploy this solution for your end users. From their Transparency Note you can read about what the Copilot in Bing team has done from a Responsible AI perspective, and what you may want to consider doing to help improve the safety of your solution.
+This system behavior is similar to Copilot in Bing. We suggest reviewing their [Transparency Note](https://support.microsoft.com/en-us/topic/Copilot-in-bing-our-approach-to-responsible-ai-45b5eae8-7466-43e1-ae98-b48f8ff8fd44) as well when considering if you want to deploy this solution for your end users. From their Transparency Note you can read about what the Copilot in Bing team has done from a Responsible AI perspective, and what you may want to consider doing to help improve the safety of your solution.
 
 The system differentiates the externally-grounded answers from the other answers provided by the system via visual cues and system messages presented to the end user. If modifying the user experience, care should be taken to ensure that end users can easily distinguish where the grounding is coming from, or if the answer is ungrounded. 
 
@@ -221,31 +221,31 @@ Note that there are several potential security concerns with LangChain and the a
 
 This system is intended for the purpose of exploring LLM capabilities across several data sources (internal and exteral) and engagement methods. Engagement methods range from heavily controlled to completely uncontrolled, sometimes leveraging prompt engineering to limit the creativity of the model(s) and citations to help the end user determine when answers are factual, while other times being minimally controlling (ungrounded responses). As such, much care has been taken to build the system with best practices in mind as a means to help the end user understand what it happening when they see responses from the system. 
 
-As features in this copilot template may be turned on/off at deployment time, it allows customizability for the design of the system which will be presented to the end user (the solution). Additionally this copilot template leverages many core product features such as Bing Web Search API for LLMs and Content Safety (filtering) to allow varying levels of control in the system which can not be accounted for in this Transparency Note. It is imperative to consider your specific use case when combining features, along with the resources available in the [Responsible AI guideance](#learn-more-about-responsible-ai) as you prepare your individual solution. 
+As features in this agent template may be turned on/off at deployment time, it allows customizability for the design of the system which will be presented to the end user (the solution). Additionally this agent template leverages many core product features such as Bing Web Search API for LLMs and Content Safety (filtering) to allow varying levels of control in the system which can not be accounted for in this Transparency Note. It is imperative to consider your specific use case when combining features, along with the resources available in the [Responsible AI guideance](#learn-more-about-responsible-ai) as you prepare your individual solution. 
 
 ## Considerations when choosing a use case
 
 ### Identity Applications
-**Avoid using IA copilot template for identification or verification of identities or processing of biometric information.** Any use cases that seek to incorporate end consumer or citizen data should be carefully evaluated per Microsoft’s Responsible AI guidelines.
+**Avoid using IA agent template for identification or verification of identities or processing of biometric information.** Any use cases that seek to incorporate end consumer or citizen data should be carefully evaluated per Microsoft’s Responsible AI guidelines.
 
 ### Age Appropriateness/Exposure to Minors
 
-This copilot template contains features which have been requested by our Education industry leaders and customers. Microsoft is aware that **there are significant potential harms when exposing minors to Generative AI and Internet content** (as may be provided via Bing Web Search API for LLMs). Microsoft is also aware that there are regional legal limitations which may govern the application of these technologies, especially when delivered to minors. The technology **systems available at the time of this writing are unable to mitigate all potential harms and meet all legal limitations. This copilot template does not address these concerns.**
+This agent template contains features which have been requested by our Education industry leaders and customers. Microsoft is aware that **there are significant potential harms when exposing minors to Generative AI and Internet content** (as may be provided via Bing Web Search API for LLMs). Microsoft is also aware that there are regional legal limitations which may govern the application of these technologies, especially when delivered to minors. The technology **systems available at the time of this writing are unable to mitigate all potential harms and meet all legal limitations. This agent template does not address these concerns.**
 
-**At this time, these capabilities SHOULD NOT be targeted to minors.** The capabilities in this copilot template should only be targeted to adult users.
+**At this time, these capabilities SHOULD NOT be targeted to minors.** The capabilities in this agent template should only be targeted to adult users.
 
 Current known limitations with respect to minors:
 * Bing Safe Search is limited to filtering Adult Content in text and image form
 * Content Safety features may be enabled but are not comprehensive enough to limit all potential harms related to self harm, hate speech, racism, terrorism and violence
 * Content Safety does not support some regional legal requirements including ability to limit religious content and content related to sexual oreintation 
-* Age-adaptive prompting is not implemented in this copilot template
-* This copilot template does not have age awareness
-* This copilot template does not utilize, collect or store guardian consent
-* This copilot template does not store user interaction history in any form including user identifiers, queries or responses
-*  This copilot template may not have adequeate features to prevent "jailbraking" of the system to bypass harm mitigations
-# Limitations of IA copilot template
+* Age-adaptive prompting is not implemented in this agent template
+* This agent template does not have age awareness
+* This agent template does not utilize, collect or store guardian consent
+* This agent template does not store user interaction history in any form including user identifiers, queries or responses
+*  This agent template may not have adequeate features to prevent "jailbraking" of the system to bypass harm mitigations
+# Limitations of IA agent template
 
-In this section we describe several known limitations of the IA copilot template system.
+In this section we describe several known limitations of the IA agent template system.
 
 ## Qualitative limitations, human oversight requirements
 
@@ -261,7 +261,7 @@ This system provides citations for all grounded answers given. All answers, grou
 
 ### Non-Production Status
 
-This software is a copilot template codebase that is not configured for production use. Effort MUST BE taken to ensure that appropriate data security practices are followed to be compliant with local regulations in alignment with the classification of data intended to be used with this system.
+This software is a agent template codebase that is not configured for production use. Effort MUST BE taken to ensure that appropriate data security practices are followed to be compliant with local regulations in alignment with the classification of data intended to be used with this system.
 
 **Microsoft does not provide technical support for this codebase in a production setting.**
 
@@ -271,13 +271,13 @@ This software is not intended for real-time data processing. This is a batch-pro
 
 ### Request Throttling
 
-The Azure OpenAI API and other systems may be subject to throttling. As such this copilot template may have performance limitations and should not be placed into a mission-critical operation without confirmed provisioned throughput (PTU) or appropriate service agreements in place.
+The Azure OpenAI API and other systems may be subject to throttling. As such this agent template may have performance limitations and should not be placed into a mission-critical operation without confirmed provisioned throughput (PTU) or appropriate service agreements in place.
 
 # System performance
 
 ## Grounded experiences
 
-The central part of IA copilot template (the system) is to produce answers to questions with the data provided, either by the end user or web results (grounded). This relies on several conditions for accuracy in the response to any given question. At a minimum accurate responses rely on:
+The central part of IA agent template (the system) is to produce answers to questions with the data provided, either by the end user or web results (grounded). This relies on several conditions for accuracy in the response to any given question. At a minimum accurate responses rely on:
 
 - documents with the answers available to the system
 - submitted documents having been successfully processed
@@ -299,15 +299,15 @@ During web-grounded interactions, human oversight is required to verify the vail
 
 ## Ungrounded experiences
 
-There have been no performance criteria established for the ungrounded experiences presented in this copilot template. Performance criteria SHOULD BE established for your intended use case.
+There have been no performance criteria established for the ungrounded experiences presented in this agent template. Performance criteria SHOULD BE established for your intended use case.
 
-# Evaluation of IA copilot template
+# Evaluation of IA agent template
 
-At the time of this writing, this copilot template is in a **Released state with Preview features**. Microsoft has evaluated this codebase to be fit for purpose to a degree where we are comfortable to start engaging 3rd Party organizations and users to help with the evaluation of the system to determine if it is fit for their purposes. There are several backlog features targeted for future sprints which should help address confidence scoring and improve relevance of answers. As these and additional features are developed they, and the system, will continue to be evaluated.
+At the time of this writing, this agent template is in a **Released state with Preview features**. Microsoft has evaluated this codebase to be fit for purpose to a degree where we are comfortable to start engaging 3rd Party organizations and users to help with the evaluation of the system to determine if it is fit for their purposes. There are several backlog features targeted for future sprints which should help address confidence scoring and improve relevance of answers. As these and additional features are developed they, and the system, will continue to be evaluated.
 
-## Evaluating and Integrating IA copilot template for your use
+## Evaluating and Integrating IA agent template for your use
 
-This section outlines best practices for using IA copilot template responsibly to achieve best performance from the system.
+This section outlines best practices for using IA agent template responsibly to achieve best performance from the system.
 
 ### Human-in-the-loop
 
@@ -325,13 +325,13 @@ The system outcomes need to be evaluated by the user to determine the accuracy o
 
 The technical documentation provided with this system should be used to achieve the best outcomes. Care should be used when tuning, especially in the form of prompt engineering. Trade-offs between accuracy versus creativity should be understood when choices are made.
 
-You can find the technical documentation in our [Using IA copilot template for the first time](../README.md#using-IA-for-the-first-time) section.
+You can find the technical documentation in our [Using IA agent template for the first time](../README.md#using-IA-for-the-first-time) section.
 
 # Technical limitations, operational factors and ranges
 
 **This system has not been evaluated for its intended purpose against your data!**
 
-This system makes no claim for precision or accuracy. The behavior and performance of IA copilot template depends on the type, volume and quality of data ingested to it. This data will differ across end users, and therefore it is not possible to make a generic evaluation of IA copilot template for your purposes.
+This system makes no claim for precision or accuracy. The behavior and performance of IA agent template depends on the type, volume and quality of data ingested to it. This data will differ across end users, and therefore it is not possible to make a generic evaluation of IA agent template for your purposes.
 
 # Learn more about responsible AI
 
@@ -342,10 +342,10 @@ This system makes no claim for precision or accuracy. The behavior and performan
 
 [Microsoft Azure Learning courses on responsible AI](https://docs.microsoft.com/en-us/learn/paths/responsible-ai-business-principles/)
 
-# Learn more about the IA copilot template
+# Learn more about the IA agent template
 
 
-[Information Assistant copilot template](https://github.com/microsoft/PubSec-Info-Assistant)
+[Information Assistant agent template](https://github.com/microsoft/PubSec-Info-Assistant)
 
 
 # Contact us

--- a/docs/webapp_debug.md
+++ b/docs/webapp_debug.md
@@ -1,6 +1,6 @@
 # Debugging the Information Assistant Web App in VS Code
 
-If you wish to debug the user interface, or web app that as part of this copilot template, you can do this locally in VS Code and step through the logic. 
+If you wish to debug the user interface, or web app that as part of this agent template, you can do this locally in VS Code and step through the logic. 
 
 The app consists of two layers, namely the frontend user interface components and the backend logic components. As a user interacts with the user interface, they are engaging with the frontend code, and control is passed to the back end code as needed, for example to make calls to the Azure OpenAI service.
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -60,4 +60,4 @@ Once deployed, you can find the URL of your installation by:
 
 ## Next steps
 
-At this point deployment is complete. Please go to the [Using the IA agent template for the first time](../README.md#using-ia-agent-template-for-the-first-time) section and complete the following steps.
+At this point deployment is complete. Please follow the [instructions for using the IA agent template for the first time](/docs/deployment/using_ia_first_time.md).

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,6 +1,6 @@
 # Configure Azure resources
 
-## Deploying the Information Assistant (IA) copilot template
+## Deploying the Information Assistant (IA) agent template
 
 Now that your Codespace/Dev Container and ENV files are configured, it is time to deploy the Azure resources. This is done using a `Makefile`.
 
@@ -60,4 +60,4 @@ Once deployed, you can find the URL of your installation by:
 
 ## Next steps
 
-At this point deployment is complete. Please go to the [Using the IA copilot template for the first time](../README.md#using-ia-copilot-template-for-the-first-time) section and complete the following steps.
+At this point deployment is complete. Please go to the [Using the IA agent template for the first time](../README.md#using-ia-agent-template-for-the-first-time) section and complete the following steps.

--- a/scripts/environments/local.env.example
+++ b/scripts/environments/local.env.example
@@ -130,7 +130,7 @@ export CHAT_WARNING_BANNER_TEXT=""
 # A pointer to a supported language ENV file located in the ./languages folder.
 export DEFAULT_LANGUAGE="en-US" # Required
 
-# If you are deploying this for a customer, you can optionally set the following values to track usage of the copilot template.
+# If you are deploying this for a customer, you can optionally set the following values to track usage of the agent template.
 # This uses the pattern of Customer Usage Attribution, more info can be found at https://learn.microsoft.com/en-us/partner-center/marketplace/azure-partner-customer-usage-attribution 
 export ENABLE_CUSTOMER_USAGE_ATTRIBUTION=true
 export CUSTOMER_USAGE_ATTRIBUTION_ID="7a01ff74-15c2-4fec-9f14-63db7d3d6131"

--- a/scripts/environments/shared-ia-dev.env
+++ b/scripts/environments/shared-ia-dev.env
@@ -80,7 +80,7 @@ export SKIP_PLAN_CHECK=1
 
 export DEFAULT_LANGUAGE="en-US"
 
-# If you are deploying this for a customer, you can optionally set the following values to track usage of the copilot template.
+# If you are deploying this for a customer, you can optionally set the following values to track usage of the agent template.
 # This uses the pattern of Customer Usage Attribution, more info can be found at https://learn.microsoft.com/en-us/partner-center/marketplace/azure-partner-customer-usage-attribution 
 export ENABLE_CUSTOMER_USAGE_ATTRIBUTION=false
 export CUSTOMER_USAGE_ATTRIBUTION_ID=""

--- a/scripts/environments/shared-ia.env
+++ b/scripts/environments/shared-ia.env
@@ -80,7 +80,7 @@ export SKIP_PLAN_CHECK=1
 
 export DEFAULT_LANGUAGE="en-US"
 
-# If you are deploying this for a customer, you can optionally set the following values to track usage of the copilot template.
+# If you are deploying this for a customer, you can optionally set the following values to track usage of the agent template.
 # This uses the pattern of Customer Usage Attribution, more info can be found at https://learn.microsoft.com/en-us/partner-center/marketplace/azure-partner-customer-usage-attribution 
 export ENABLE_CUSTOMER_USAGE_ATTRIBUTION=false
 export CUSTOMER_USAGE_ATTRIBUTION_ID=""

--- a/scripts/environments/tmp-ia.env
+++ b/scripts/environments/tmp-ia.env
@@ -80,7 +80,7 @@ export SKIP_PLAN_CHECK=1
 
 export DEFAULT_LANGUAGE="en-US"
 
-# If you are deploying this for a customer, you can optionally set the following values to track usage of the copilot template.
+# If you are deploying this for a customer, you can optionally set the following values to track usage of the agent template.
 # This uses the pattern of Customer Usage Attribution, more info can be found at https://learn.microsoft.com/en-us/partner-center/marketplace/azure-partner-customer-usage-attribution 
 export ENABLE_CUSTOMER_USAGE_ATTRIBUTION=false
 export CUSTOMER_USAGE_ATTRIBUTION_ID=""

--- a/scripts/environments/usgov-ia.env
+++ b/scripts/environments/usgov-ia.env
@@ -79,7 +79,7 @@ export SKIP_PLAN_CHECK=1
 
 export DEFAULT_LANGUAGE="en-US"
 
-# If you are deploying this for a customer, you can optionally set the following values to track usage of the copilot template.
+# If you are deploying this for a customer, you can optionally set the following values to track usage of the agent template.
 # This uses the pattern of Customer Usage Attribution, more info can be found at https://learn.microsoft.com/en-us/partner-center/marketplace/azure-partner-customer-usage-attribution 
 export ENABLE_CUSTOMER_USAGE_ATTRIBUTION=false
 export CUSTOMER_USAGE_ATTRIBUTION_ID=""

--- a/scripts/inf-import-state.sh
+++ b/scripts/inf-import-state.sh
@@ -33,7 +33,7 @@ echo "Please read the following terms carefully. You must accept the terms to pr
 echo
 echo "This script will import the existing resources into the Terraform state."
 echo "You may then run a MAKE DEPLOY on this environment to deploy the latest version"
-echo "of the copilot template while maintaining your existing resources and processed data."
+echo "of the agent template while maintaining your existing resources and processed data."
 echo
 echo "If you have modified the infrastructure base this process will fail."
 echo "The simplest approach to deploy the latest version would be to perform"


### PR DESCRIPTION
replaced 'copilot' with 'agent' for all little 'c' copilots. Big "C" Copilots remain where appropriate.