### PR TITLE
Python Version and Requirements Upgrades

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/vscode/devcontainers/python:3.10-bookworm
+FROM mcr.microsoft.com/vscode/devcontainers/python:3.12-bookworm
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive

--- a/app/backend/approaches/chatreadretrieveread.py
+++ b/app/backend/approaches/chatreadretrieveread.py
@@ -13,7 +13,7 @@ from openai import  AsyncAzureOpenAI
 from openai import BadRequestError
 from approaches.approach import Approach
 from azure.search.documents import SearchClient  
-from azure.search.documents.models import RawVectorQuery
+from azure.search.documents.models import VectorizedQuery
 from azure.search.documents.models import QueryType
 from azure.storage.blob import (
     BlobSasPermissions,
@@ -245,7 +245,7 @@ class ChatReadRetrieveReadApproach(Approach):
             return # Go no further
         
         #vector set up for pure vector search & Hybrid search & Hybrid semantic
-        vector = RawVectorQuery(vector=embedded_query_vector, k=top, fields="contentVector")
+        vector = VectorizedQuery(vector=embedded_query_vector, k_nearest_neighbors=top, fields="contentVector")
 
         #Create a filter for the search query
         if (folder_filter != "") & (folder_filter != "All"):

--- a/app/backend/approaches/mathassistant.py
+++ b/app/backend/approaches/mathassistant.py
@@ -6,9 +6,12 @@
 import os
 import warnings
 from dotenv import load_dotenv
+from typing import ClassVar
+
 from langchain_openai import AzureChatOpenAI
-from langchain.agents import initialize_agent, load_tools, AgentType
+from langchain.agents import initialize_agent, AgentType
 from langchain.prompts import ChatPromptTemplate
+from langchain_community.agent_toolkits.load_tools import load_tools
 from azure.identity import ManagedIdentityCredential, AzureAuthorityHosts, DefaultAzureCredential, get_bearer_token_provider
 
 warnings.filterwarnings('ignore')
@@ -51,8 +54,8 @@ desc = (
 )
 
 class PythagorasTool(BaseTool):
-    name = "Hypotenuse calculator"
-    description = desc
+    name: ClassVar[str] = "Hypotenuse calculator"
+    description: ClassVar[str] = desc
     
     def _run(
         self,
@@ -83,8 +86,8 @@ from math import pi
   
 
 class CircumferenceTool(BaseTool):
-    name = "Circumference calculator"
-    description = "use this tool when you need to calculate a circumference using the radius of a circle"
+    name: ClassVar[str] = "Circumference calculator"
+    description: ClassVar[str] = "use this tool when you need to calculate a circumference using the radius of a circle"
 
     def _run(self, radius: Union[int, float]):
         return float(radius)*2.0*pi

--- a/app/backend/approaches/tabulardataassistant.py
+++ b/app/backend/approaches/tabulardataassistant.py
@@ -12,6 +12,7 @@ from PIL import Image
 from langchain_experimental.agents.agent_toolkits import create_pandas_dataframe_agent
 from langchain.agents.agent_types import AgentType
 from langchain_openai import AzureChatOpenAI
+from langchain_community.agent_toolkits.load_tools import load_tools
 from azure.identity import ManagedIdentityCredential, AzureAuthorityHosts, DefaultAzureCredential, get_bearer_token_provider
 
 warnings.filterwarnings('ignore')

--- a/app/backend/pyvenv.cfg
+++ b/app/backend/pyvenv.cfg
@@ -1,3 +1,3 @@
 home = /workspaces/info-asst/.venv/bin
 include-system-site-packages = false
-version = 3.10.12
+version = 3.12.6

--- a/app/backend/requirements.txt
+++ b/app/backend/requirements.txt
@@ -1,28 +1,27 @@
 #### Any version change made here should also be made and tested for the enrichment and function apps in /functions and /app/enrichment
-azure-identity==1.16.1
-Flask==2.3.2
-langchain==0.2.10
+azure-cosmos==4.7.0
+azure-identity==1.18.0
 azure-mgmt-cognitiveservices==13.5.0
-openai==1.35.8
-# azure-search-documents==11.4.0
-azure-search-documents==11.4.0b11
-azure-storage-blob==12.20.0
-azure-cosmos == 4.7.0
-tiktoken == 0.7.0
-fastapi == 0.109.1
-fastapi-utils == 0.2.1
-uvicorn == 0.23.2
-numexpr == 2.10.0
-langchain-experimental==0.0.62
+azure-search-documents==11.5.1
+azure-storage-blob==12.23.0
+fastapi==0.115.0
+fastapi-utils==0.7.0
+Flask==3.0.3
+gunicorn==23.0.0
+langchain==0.3.1
+langchain-community==0.3.1 
+langchain-experimental==0.3.2
+langchain-openai==0.2.1
+matplotlib==3.9.2
 microsoft-bing-websearch==1.0.0
+numexpr==2.10.1
+openai==1.49.0
+pandas==2.2.3
+Pillow==10.4.0
+pytest==8.3.3
+python-dotenv==1.0.1
+python-multipart==0.0.10
 tabulate==0.9.0
-matplotlib==3.8.3
-python-dotenv==1.0.1
-pandas==2.2.1
-python-multipart==0.0.9
-Pillow==10.3.0
+tiktoken==0.7.0
+uvicorn==0.30.6
 wikipedia==1.4.0
-langchain-openai == 0.1.14
-pytest==8.2.1
-python-dotenv==1.0.1
-langchain-community==0.2.9 

--- a/app/enrichment/pyvenv.cfg
+++ b/app/enrichment/pyvenv.cfg
@@ -1,3 +1,3 @@
 home = /workspaces/info-asst/.venv/bin
 include-system-site-packages = false
-version = 3.10.12
+version = 3.12.6

--- a/app/enrichment/requirements.txt
+++ b/app/enrichment/requirements.txt
@@ -1,17 +1,17 @@
 #### Any version change made here should also be made and tested for the webapp backend and function apps in /functions and /app/backend
 --extra-index-url https://download.pytorch.org/whl/cpu
+azure-core==1.31.0
+azure-cosmos==4.7.0
+azure-storage-blob==12.23.1
+azure-storage-queue==12.12.0
+azure-search-documents==11.5.1
+azure-identity==1.18.0
+fastapi==0.115.0
+fastapi-utils==0.7.0
+openai==1.50.2
+sentence-transformers==3.1.1
+tenacity==9.0.0
 torch
 torchvision
 torchaudio
-sentence-transformers == 2.3.0
-fastapi == 0.109.1
-fastapi-utils == 0.2.1
-uvicorn == 0.23.2
-azure-storage-queue == 12.6.0
-azure-storage-blob==12.16.0
-azure.search.documents==11.5.1
-azure-cosmos == 4.7.0
-azure-core == 1.30.2
-azure-identity==1.16.1
-tenacity == 8.2.3
-openai==1.17.0
+uvicorn==0.31.0

--- a/container_images/enrichment_container_image/Dockerfile
+++ b/container_images/enrichment_container_image/Dockerfile
@@ -1,5 +1,5 @@
 # Use the official Python image from Microsoft for Azure App Service
-FROM mcr.microsoft.com/devcontainers/python:3.10
+FROM mcr.microsoft.com/devcontainers/python:3.12
 
 # Set the working directory
 WORKDIR /app

--- a/container_images/webapp_container_image/Dockerfile
+++ b/container_images/webapp_container_image/Dockerfile
@@ -1,5 +1,5 @@
 # Use the official Node.js image
-FROM mcr.microsoft.com/devcontainers/python:3.10
+FROM mcr.microsoft.com/devcontainers/python:3.12
 
 # Set the working directory
 WORKDIR /home/site/wwwroot

--- a/functions/Dockerfile
+++ b/functions/Dockerfile
@@ -1,6 +1,6 @@
 # To enable ssh & remote debugging on app service change the base image to the one below
-# FROM mcr.microsoft.com/azure-functions/python:4-python3.10-appservice
-FROM mcr.microsoft.com/azure-functions/python:4-python3.10
+# FROM mcr.microsoft.com/azure-functions/python:4-python3.12-appservice
+FROM mcr.microsoft.com/azure-functions/python:4-python3.12
 
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true

--- a/functions/requirements.txt
+++ b/functions/requirements.txt
@@ -4,18 +4,20 @@
 
 #### Any version change made here should also be made and tested for the web apps in /app/backend and /app/enrichment
 
-azure-functions == 1.17.0
+azure-ai-formrecognizer==3.3.3
+azure-ai-vision-imageanalysis==1.0.0b3
+azure-core==1.31.0
+azure-cosmos==4.7.0
+azure-functions==1.21.0
+azure-identity==1.18.0
+azure-search-documents==11.5.1
+azure-storage-blob==12.23.1
+azure-storage-queue==12.12.0
+beautifulsoup4==4.12.3
+cryptography==43.0.1
+lxml==5.3.0
+nltk==3.9.1
+pyoo==1.4
+tenacity==9.0.0
 tiktoken==0.7.0
-azure.ai.formrecognizer==3.2.1
-azure-storage-blob==12.20.0
-azure-core == 1.30.2
-lxml == 4.9.2
-azure-cosmos == 4.7.0
-azure-storage-queue == 12.6.0
-nltk == 3.9.1
-tenacity == 8.2.3
-unstructured[csv,doc,docx,email,html,md,msg,ppt,pptx,text,xlsx,xml] == 0.15.9
-pyoo == 1.4
-azure-search-documents == 11.4.0b11
-beautifulsoup4 == 4.12.2
-azure-identity==1.17.1
+unstructured[csv,doc,docx,email,html,md,msg,ppt,pptx,text,xlsx,xml] == 0.15.13

--- a/infra/core/host/webapp/variables.tf
+++ b/infra/core/host/webapp/variables.tf
@@ -119,7 +119,7 @@ variable "allowedOrigins" {
 
 variable "runtimeVersion" {
   type    = string
-  default = "3.10"
+  default = "3.12"
 }
 
 variable "is_secure_mode" {

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -341,7 +341,7 @@ module "webapp" {
   resourceGroupName                   = azurerm_resource_group.rg.name
   location                            = var.location
   tags                                = merge(local.tags, { "azd-service-name" = "backend" })
-  runtimeVersion                      = "3.10" 
+  runtimeVersion                      = "3.12" 
   scmDoBuildDuringDeployment          = false
   managedIdentity                     = true
   alwaysOn                            = true


### PR DESCRIPTION
This pull request is to upgrade the PubSec-Info-Assistant solution both in terms of the baseline [Python version](https://devguide.python.org/versions/#python-release-cycle) (from Python 3.10 to Python 3.12) as well as update to the latest baseline of Python Modules available from PyPI as many of the reference modules are dated (some over 18 months old).  This update will enable the PubSec-Info-Assistant solution to continue advancement of overall baseline security.