### PR TITLE
Upgrading the version of unstructured package to the latest to fix th…

### DIFF
--- a/functions/requirements.txt
+++ b/functions/requirements.txt
@@ -20,4 +20,4 @@ nltk==3.9.1
 pyoo==1.4
 tenacity==9.0.0
 tiktoken==0.7.0
-unstructured[csv,doc,docx,email,html,md,msg,ppt,pptx,text,xlsx,xml] == 0.15.13
+unstructured[csv,doc,docx,email,html,md,msg,ppt,pptx,text,xlsx,xml] == 0.16.17


### PR DESCRIPTION
A prior version to 0.16.16 of unstructured module causes the FileLayoutParsingOther to start failing with a Forbidden Error. 
![image](https://github.com/user-attachments/assets/4bce51d0-e4dd-4753-91b0-bffbc818ad42)
This PR upgraded the version of unstructured module to 0.16.17 (latest version) to fix the Forbidden error.
![image](https://github.com/user-attachments/assets/b3b0ef09-8c1a-436b-aba7-af3daee709de)
